### PR TITLE
debugger og console.* skal gi error ved commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,15 @@
         "build": "craco build",
         "build:mock": "cross-env PUBLIC_URL=/veilarbvisittkortfs REACT_APP_DEV=true craco build",
         "test": "echo not implemented",
-        "prettier": "prettier --write 'src/**/*.ts{,x}'"
+        "prettier": "prettier --write 'src/**/*.ts{,x}'",
+        "lint": "eslint src"
     },
     "eslintConfig": {
-        "extends": "react-app"
+        "extends": "react-app",
+      "rules": {
+        "no-debugger": "error",
+        "no-console": "error"
+      }
     },
     "browserslist": [
         ">0.2%",
@@ -28,7 +33,8 @@
     },
     "lint-staged": {
         "src/**/*.{ts,tsx}": [
-            "prettier --write"
+            "prettier --write",
+            "eslint src"
         ]
     },
     "dependencies": {

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -4,6 +4,6 @@ import { allHandlers } from './api';
 setupWorker(...allHandlers)
     .start({ serviceWorker: { url: process.env.PUBLIC_URL + '/mockServiceWorker.js' } })
     .catch(e => {
-        // tslint:disable-next-line:no-console
+        // eslint-disable-next-line no-console
         console.error('Unable to setup mocked API endpoints', e);
     });

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -9,7 +9,7 @@ export interface FrontendEvent {
 
 export const logMetrikk = (name: string, fields?: {}, tags?: {}): void => {
     if (isDevelopment()) {
-        // tslint:disable-next-line:no-console
+        // eslint-disable-next-line no-console
         console.log('Event', name, 'Fields:', fields, 'Tags:', tags);
     } else {
         sendEventTilVeilarbperson({ name, fields, tags });


### PR DESCRIPTION
Utvider `lint-staged` til å også køyre `eslint` ved pre-commit. Legger til `no-console` og `no-debugger` med `error` nivå slik at vi hindrer å commite `debugger` og `console.*` statements (med mindre desse er eksplisitt ønsket - i såfall kan man legge til `// eslint-disable-next-line ...`).