### PR TITLE
Separate eslint config for local og lint-staged

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "extends": [
+    "react-app"
+  ],
+  "rules": {
+    "no-debugger": "warn",
+    "no-console": "warn"
+  }
+}

--- a/.eslintrc.lintstaged.json
+++ b/.eslintrc.lintstaged.json
@@ -1,0 +1,9 @@
+{
+  "extends": [
+    "react-app"
+  ],
+  "rules": {
+    "no-debugger": "error",
+    "no-console": "error"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,13 +10,6 @@
         "prettier": "prettier --write 'src/**/*.ts{,x}'",
         "lint": "eslint src"
     },
-    "eslintConfig": {
-        "extends": "react-app",
-      "rules": {
-        "no-debugger": "error",
-        "no-console": "error"
-      }
-    },
     "browserslist": [
         ">0.2%",
         "not dead",
@@ -34,7 +27,7 @@
     "lint-staged": {
         "src/**/*.{ts,tsx}": [
             "prettier --write",
-            "eslint src"
+            "eslint src --config .eslintrc.lintstaged.json"
         ]
     },
     "dependencies": {


### PR DESCRIPTION
Legger til separate config-filer for eslint for henholdsvis lokal utvikling og når `lint-staged` kjører, slik at vi kan bruke feks. `debugger` statements lokalt under utvikling med `warning`-nivå i stedet for `error` (som knekker appen). Når pre-commit hooken/ lint-staged kjører derimot så brukes egen eslint config (`.eslintrc.lintstaged.json`) der vi beholder `error` nivå og hindrer commit dersom koden inneholder `debugger`/ `console.*`.