### PR TITLE
Legg til arbeidssøkerregistrering som tillatt origin

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -36,7 +36,10 @@ spec:
       value: >
         {
           "cors": {
-            "origin": "https://veilarbpersonflate.intern.dev.nav.no"
+            "origin": [
+              "https://veilarbpersonflate.intern.dev.nav.no",
+              "https://arbeidssokerregistrering.intern.dev.nav.no"
+            ]
           },
           "gcs": {
             "bucketName": "veilarbvisittkortfs-dev"

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -36,7 +36,10 @@ spec:
       value: >
         {
           "cors": {
-            "origin": "https://veilarbpersonflate.intern.nav.no"
+            "origin": [
+              "https://veilarbpersonflate.intern.nav.no",
+              "https://arbeidssokerregistrering.intern.nav.no"
+            ]
           },
           "gcs": {
             "bucketName": "veilarbvisittkortfs-prod"


### PR DESCRIPTION
Når vi gikk over til å bruke poao-frontend så har vi samtidig tatt i bruk for "strenge" cors-regler. Legger derfor til arbeidssøkerregistrering som tillatt origin.

Ref: https://nav-it.slack.com/archives/CQ2H1AY3Z/p1678427538789819?thread_ts=1678095853.805939&cid=CQ2H1AY3Z