### PR TITLE
TC-381 bruk utrullings api i stedet for funksjonsbryter

### DIFF
--- a/src/api/veilarbpersonflatefs.ts
+++ b/src/api/veilarbpersonflatefs.ts
@@ -2,12 +2,10 @@ import { AxiosPromise } from 'axios';
 import { axiosInstance } from './utils';
 
 export const PILOT_TOGGLE = 'pto.vedtaksstotte.pilot';
-export const VEDTAKSSTTOTTE_PRELANSERING_TOGGLE = 'veilarbvedtaksstottefs.prelansering';
-export const ALL_TOGGLES = [PILOT_TOGGLE, VEDTAKSSTTOTTE_PRELANSERING_TOGGLE];
+export const ALL_TOGGLES = [PILOT_TOGGLE];
 
 export interface FeatureToggles {
     [PILOT_TOGGLE]: boolean;
-    [VEDTAKSSTTOTTE_PRELANSERING_TOGGLE]: boolean;
 }
 
 export function fetchFeaturesToggles(): AxiosPromise<FeatureToggles> {

--- a/src/api/veilarbvedtaksstotte.ts
+++ b/src/api/veilarbvedtaksstotte.ts
@@ -4,3 +4,7 @@ import { AxiosPromise } from 'axios';
 export function fetchHarUtkast(fnr: string): AxiosPromise<boolean> {
     return axiosInstance.get<boolean>(`/veilarbvedtaksstotte/api/utkast/${fnr}/harUtkast`);
 }
+
+export function fetchErUtrullet(enhet: string): AxiosPromise<boolean> {
+    return axiosInstance.get<boolean>(`/veilarbvedtaksstotte/api/utrulling/erUtrullet?enhet=${enhet}`);
+}

--- a/src/component/veilederverktoy/avsluttoppfolging/avslutt-oppfolging.tsx
+++ b/src/component/veilederverktoy/avsluttoppfolging/avslutt-oppfolging.tsx
@@ -5,29 +5,29 @@ import { VarselModal } from '../../components/varselmodal/varsel-modal';
 import dayjs from 'dayjs';
 import { useAppStore } from '../../../store/app-store';
 import { useModalStore } from '../../../store/modal-store';
-import { useDataStore } from '../../../store/data-store';
 import { selectHarUbehandledeDialoger } from '../../../util/selectors';
 import { LasterModal } from '../../components/lastermodal/laster-modal';
 import { fetchDialoger } from '../../../api/veilarbdialog';
-import { VEDTAKSSTTOTTE_PRELANSERING_TOGGLE } from '../../../api/veilarbpersonflatefs';
 import { useAxiosFetcher } from '../../../util/hook/use-axios-fetcher';
 import { fetchAvsluttOppfolgingStatus } from '../../../api/veilarboppfolging';
 import { isAnyLoading } from '../../../api/utils';
 import { logMetrikk } from '../../../util/logger';
+import { fetchErUtrullet } from '../../../api/veilarbvedtaksstotte';
 
 const for28dagerSiden = dayjs().subtract(28, 'day').toISOString();
 
 function AvsluttOppfolging() {
-    const { brukerFnr, avsluttOppfolgingOpptelt, setAvsluttOppfolgingOpptelt } = useAppStore();
-    const { features } = useDataStore();
+    const { brukerFnr, avsluttOppfolgingOpptelt, setAvsluttOppfolgingOpptelt, enhetId } = useAppStore();
     const { showtAvsluttOppfolgingBekrefModal: showAvsluttOppfolgingBekrefModal, hideModal } = useModalStore();
 
     const avsluttOppfolgingFetcher = useAxiosFetcher(fetchAvsluttOppfolgingStatus);
     const dialogFetcher = useAxiosFetcher(fetchDialoger);
+    const erUtrulletFetcher = useAxiosFetcher(fetchErUtrullet);
 
     const avslutningStatus = avsluttOppfolgingFetcher.data;
     const datoErInnenFor28DagerSiden = (avslutningStatus?.inaktiveringsDato || 0) > for28dagerSiden;
     const harUbehandledeDialoger = dialogFetcher.data ? selectHarUbehandledeDialoger(dialogFetcher.data) : false;
+    const nyVedtakslosningUtrullet = erUtrulletFetcher.data ?? false;
 
     function handleSubmitAvsluttOppfolging(values: BegrunnelseValues) {
         showAvsluttOppfolgingBekrefModal({ begrunnelse: values.begrunnelse });
@@ -39,7 +39,14 @@ function AvsluttOppfolging() {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [brukerFnr]);
 
-    if (isAnyLoading(dialogFetcher, avsluttOppfolgingFetcher)) {
+    useEffect(() => {
+        if (enhetId) {
+            erUtrulletFetcher.fetch(enhetId);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [enhetId]);
+
+    if (isAnyLoading(dialogFetcher, avsluttOppfolgingFetcher, erUtrulletFetcher)) {
         return <LasterModal />;
     }
 
@@ -77,7 +84,7 @@ function AvsluttOppfolging() {
             isLoading={false}
             infoTekst={
                 <AvsluttOppfolgingInfoText
-                    vedtaksstottePrelanseringEnabled={features[VEDTAKSSTTOTTE_PRELANSERING_TOGGLE]}
+                    visVarselDersom14aUtkastEksisterer={nyVedtakslosningUtrullet}
                     avslutningStatus={avslutningStatus}
                     datoErInnenFor28DagerSiden={datoErInnenFor28DagerSiden}
                     harUbehandledeDialoger={harUbehandledeDialoger}

--- a/src/component/veilederverktoy/avsluttoppfolging/components/avslutt-oppfolging-info-text.tsx
+++ b/src/component/veilederverktoy/avsluttoppfolging/components/avslutt-oppfolging-info-text.tsx
@@ -10,7 +10,7 @@ import { OrNothing } from '../../../../util/type/utility-types';
 
 export function AvsluttOppfolgingInfoText(props: {
     harYtelser?: boolean;
-    vedtaksstottePrelanseringEnabled: boolean;
+    visVarselDersom14aUtkastEksisterer: boolean;
     avslutningStatus: OrNothing<AvslutningStatus>;
     datoErInnenFor28DagerSiden: boolean;
     harUbehandledeDialoger: boolean;
@@ -20,13 +20,13 @@ export function AvsluttOppfolgingInfoText(props: {
     const harUtakstFetcher = useAxiosFetcher(fetchHarUtkast);
 
     useEffect(() => {
-        if (!props.vedtaksstottePrelanseringEnabled) {
+        if (props.visVarselDersom14aUtkastEksisterer) {
             harUtakstFetcher.fetch(props.fnr);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    if (harTiltakFetcher.loading || (!props.vedtaksstottePrelanseringEnabled && harUtakstFetcher.loading)) {
+    if (harTiltakFetcher.loading || (props.visVarselDersom14aUtkastEksisterer && harUtakstFetcher.loading)) {
         return <NavFrontendSpinner type="XL" />;
     }
 

--- a/src/mock/api/veilarbdialog.ts
+++ b/src/mock/api/veilarbdialog.ts
@@ -33,6 +33,9 @@ const mockHenvendelseData: any = {
 };
 
 export const veilarbdialogHandlers: RequestHandlersList = [
+    rest.get('/veilarbdialog/api/dialog', (req, res, ctx) => {
+        return res(ctx.delay(defaultNetworkResponseDelay), ctx.json([]));
+    }),
     rest.post('/veilarbdialog/api/dialog', (req, res, ctx) => {
         return res(ctx.delay(defaultNetworkResponseDelay), ctx.json(mockHenvendelseData));
     }),

--- a/src/mock/api/veilarbpersonflatefs.ts
+++ b/src/mock/api/veilarbpersonflatefs.ts
@@ -1,11 +1,10 @@
 import { rest } from 'msw';
 import { RequestHandlersList } from 'msw/lib/types/setupWorker/glossary';
-import { FeatureToggles, PILOT_TOGGLE, VEDTAKSSTTOTTE_PRELANSERING_TOGGLE } from '../../api/veilarbpersonflatefs';
+import { FeatureToggles, PILOT_TOGGLE } from '../../api/veilarbpersonflatefs';
 import { defaultNetworkResponseDelay } from '../config';
 
 const mockFeatures: FeatureToggles = {
-    [PILOT_TOGGLE]: true,
-    [VEDTAKSSTTOTTE_PRELANSERING_TOGGLE]: true
+    [PILOT_TOGGLE]: true
 };
 
 export const veilarbpersonflatefsHandlers: RequestHandlersList = [

--- a/src/mock/api/veilarbvedtaksstotte.ts
+++ b/src/mock/api/veilarbvedtaksstotte.ts
@@ -5,5 +5,8 @@ import { defaultNetworkResponseDelay } from '../config';
 export const veilarbvedtaksstotteHandlers: RequestHandlersList = [
     rest.get('/veilarbvedtaksstotte/api/utkast/:fnr/harutkast', (req, res, ctx) => {
         return res(ctx.delay(defaultNetworkResponseDelay), ctx.json(true));
+    }),
+    rest.get('/veilarbvedtaksstotte/api/utrulling/erUtrullet', (req, res, ctx) => {
+        return res(ctx.delay(defaultNetworkResponseDelay), ctx.json(true));
     })
 ];


### PR DESCRIPTION
Per i dag har vi en funksjonsbryter, `veilarbvedtaksstottefs.prelansering`, med litt merkelig oppførsel. Funksjonsbryteren er involvert når en veileder forsøker å avslutte oppfølging via "Veilederverktøy". Logikken per i dag er slik:

* a) dersom funksjonsbryteren er aktivert skal vi _ikke_ sjekke om det eksisterer et § 14 a-utkast (og evt. vise advarsel)
* b) dersom funksjonsbryteren ikke er aktivert _skal_ vi sjekke om det eksisterer et § 14 a-utkast (og evt. vise advarsel)

I praksis betyr det at vi per i dag sjekker om en bruker har et § 14 a-utkast uavhengig av hvilken enhet hen er under oppfølging på (siden funksjonsbryteren i prod per i dag ikke trigges for noen av enhetene, ergo den returnerer `false` og trigger b)-scenariet). Dette virker i grunnen litt rart da det bare er _en_ NAV-enhet som har den nye vedtaksløsningen skrudd på; altså, hvorfor sjekker vi etter utkast for alle enheter?

Jeg tror ønsket oppførsel, og det jeg har valgt å endre implementasjonen til, er at vi gjør følgende sjekker når en veileder forsøker å avslutte oppfølging fra "Veilederverktøy":

1. sjekk om oppfølgingsenheten til brukeren har ny vedtaksløsning skrudd på (`/veilarbvedtaksstotte/api/utrulling/erUtrullet?enhet=${enhet}`)
2. dersom kallet over returnerer true (dvs. ny vedtaksløsning er rullet ut for enheten) så sjekker vi videre om brukeren har et påbegynt utkast for et § 14 a-vedtak (`/veilarbvedtaksstotte/api/utkast/${fnr}/harUtkast`)
3. dersom brukeren har et påbegynt utkast så skal vi vise alert-meldingen
