### PR TITLE
Legger til behandlingsnummer i Requestbodyen

### DIFF
--- a/src/api/veilarbperson.ts
+++ b/src/api/veilarbperson.ts
@@ -75,6 +75,11 @@ export interface PersonRequest {
     fnr: string;
 }
 
+export interface PdlRequest {
+    fnr: string;
+    behandlingsnummer: string;
+}
+
 export type RegistreringType = 'ORDINAER' | 'SYKMELDT';
 export type InnsatsgruppeType = 'STANDARD_INNSATS' | 'SITUASJONSBESTEMT_INNSATS' | 'BEHOV_FOR_ARBEIDSEVNEVURDERING';
 
@@ -89,18 +94,25 @@ export interface RegistreringData {
     };
 }
 
-export function fetchPersonalia(fnr: string): AxiosPromise<Personalia> {
-    return axiosInstance.post<Personalia>(`/veilarbperson/api/v3/hent-person`, { fnr: fnr } as PersonRequest);
+export function fetchPersonalia(fnr: string, behandlingsnummer: string): AxiosPromise<Personalia> {
+    return axiosInstance.post<Personalia>(`/veilarbperson/api/v3/hent-person`, {
+        fnr: fnr,
+        behandlingsnummer: behandlingsnummer
+    } as PdlRequest);
 }
 
-export function fetchVergeOgFullmakt(fnr: string): AxiosPromise<VergeOgFullmakt> {
+export function fetchVergeOgFullmakt(fnr: string, behandlingsnummer: string): AxiosPromise<VergeOgFullmakt> {
     return axiosInstance.post<VergeOgFullmakt>(`/veilarbperson/api/v3/person/hent-vergeOgFullmakt`, {
-        fnr: fnr
-    } as PersonRequest);
+        fnr: fnr,
+        behandlingsnummer: behandlingsnummer
+    } as PdlRequest);
 }
 
-export function fetchSpraakTolk(fnr: string): AxiosPromise<SpraakTolk> {
-    return axiosInstance.post<SpraakTolk>(`/veilarbperson/api/v3/person/hent-tolk`, { fnr: fnr } as PersonRequest);
+export function fetchSpraakTolk(fnr: string, behandlingsnummer: string): AxiosPromise<SpraakTolk> {
+    return axiosInstance.post<SpraakTolk>(`/veilarbperson/api/v3/person/hent-tolk`, {
+        fnr: fnr,
+        behandlingsnummer: behandlingsnummer
+    } as PdlRequest);
 }
 
 //@TODO: 21/08/2023 denne skal slettes etter vi har ryddet opp i kode i de andre appene da dkif slutter å tilby tjenesten

--- a/src/component/data-fetcher.tsx
+++ b/src/component/data-fetcher.tsx
@@ -41,6 +41,7 @@ export function DataFetcher(props: { children: any }) {
     const spraakTolkFetcher = useAxiosFetcher(fetchSpraakTolk);
     const gjeldendeEskaleringsvarselFetcher = useAxiosFetcher(hentGjeldendeEskaleringsvarsel);
 
+    const behandlingsnummer = 'B643';
     const oppfolgingsEnhet = oppfolgingstatusFetcher.data?.oppfolgingsenhet.enhetId || '';
 
     useEffect(() => {
@@ -51,9 +52,9 @@ export function DataFetcher(props: { children: any }) {
             .fetch(brukerFnr)
             .then(ifResponseHasData(setGjeldendeEskaleringsvarsel))
             .catch();
-        vergeOgFullmaktFetcher.fetch(brukerFnr).then(ifResponseHasData(setVergeOgFullmakt)).catch();
-        spraakTolkFetcher.fetch(brukerFnr).then(ifResponseHasData(setSpraakTolk)).catch();
-        personaliaFetcher.fetch(brukerFnr).then(ifResponseHasData(setPersonalia)).catch();
+        vergeOgFullmaktFetcher.fetch(brukerFnr, behandlingsnummer).then(ifResponseHasData(setVergeOgFullmakt)).catch();
+        spraakTolkFetcher.fetch(brukerFnr, behandlingsnummer).then(ifResponseHasData(setSpraakTolk)).catch();
+        personaliaFetcher.fetch(brukerFnr, behandlingsnummer).then(ifResponseHasData(setPersonalia)).catch();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [brukerFnr]);
 


### PR DESCRIPTION
Hva er poenget med denne PR-en?
Denne PR-en står i sammenheng med https://github.com/navikt/veilarbperson/pull/289, men kan prodsettes uavhengig av den.

1. PDL ber om at vi sender med behandlingsnummer fra behandlingskatalogen ved requester mot PDL
2. Behandlingskatalogen er organisert etter frontender (Overblikk, Oversikten, Visittkort, etc)
3. Vi identifiserer at 3 frontendapper bruker endepunktene i veilarbperson som går videre til PDL (Overblikk, Visittkort og Mulighetsrommet)
4. I samråd med Ingunn bestemmer vi at vi skal få appene som bruker endepunktene til å sende inn behandlingsnummer selv
5. Jeg har derfor lagt til en ny type for requestbody for PDL-requester i veilarbperson. (Den godtar at behandlingsnummeret er null/tomt)
6. Jeg sender med behandlingsnummer fra frontendene (som er i denne PR-en)