### PR TITLE
Bytt til nytt designsystem: typografi-komponenter

### DIFF
--- a/src/component/arbeidsliste/arbeidsliste-form.tsx
+++ b/src/component/arbeidsliste/arbeidsliste-form.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import FormikInput from '../components/formik/formik-input';
 import FormikTekstArea from '../components/formik/formik-textarea';
 import FormikDatoVelger from '../components/formik/formik-datepicker';
-import { Undertekst, Undertittel } from 'nav-frontend-typografi';
 import ArbeidslistekategoriVisning from './arbeidslisteikon/arbeidslisteikon-visning';
 import {
     validerArbeidslisteDatoFelt,
@@ -11,6 +10,7 @@ import {
 } from '../../util/formik-validation';
 import { toSimpleDateStr } from '../../util/date-utils';
 import { OrNothing } from '../../util/type/utility-types';
+import { Detail, Heading } from '@navikt/ds-react';
 
 interface ArbeidslisteFormProps {
     sistEndretAv?: OrNothing<{ veilederId: string }>;
@@ -23,7 +23,7 @@ function ArbeidslisteForm(props: ArbeidslisteFormProps) {
     return (
         <div className="arbeidsliste__bruker">
             <div className="blokk-s">
-                <Undertittel>{`${props.navn}, ${props.fnr}`}</Undertittel>
+                <Heading size="small" as="h2">{`${props.navn}, ${props.fnr}`}</Heading>
                 <FormikInput name="overskrift" label="Tittel" validate={validerArbeidslisteTittelFelt} bredde="L" />
                 <FormikTekstArea
                     name="kommentar"
@@ -32,9 +32,9 @@ function ArbeidslisteForm(props: ArbeidslisteFormProps) {
                     validate={validerArbeidslisteKommentarFelt}
                 />
                 {props.sistEndretAv && props.endringstidspunkt && (
-                    <Undertekst className="arbeidsliste--modal-redigering">
+                    <Detail className="arbeidsliste--modal-redigering">
                         {`Oppdatert ${toSimpleDateStr(props.endringstidspunkt)} av ${props.sistEndretAv.veilederId}`}
-                    </Undertekst>
+                    </Detail>
                 )}
             </div>
             <div className="dato-kategori-wrapper">

--- a/src/component/arbeidsliste/fjern-arbeidsliste-modal.tsx
+++ b/src/component/arbeidsliste/fjern-arbeidsliste-modal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Hovedknapp, Knapp } from 'nav-frontend-knapper';
-import { Element, Innholdstittel } from 'nav-frontend-typografi';
 import { VarselModal } from '../components/varselmodal/varsel-modal';
 import { slettArbeidsliste } from '../../api/veilarbportefolje';
 import { useModalStore } from '../../store/modal-store';
@@ -10,6 +9,7 @@ import { selectSammensattNavn } from '../../util/selectors';
 import { ifResponseHasData } from '../../util/utils';
 import { logMetrikk } from '../../util/logger';
 import { trackAmplitude } from '../../amplitude/amplitude';
+import { BodyShort, Heading } from '@navikt/ds-react';
 
 function FjernArbeidslisteModal() {
     const { brukerFnr } = useAppStore();
@@ -32,8 +32,14 @@ function FjernArbeidslisteModal() {
     return (
         <VarselModal contentLabel="Fjern fra arbeidslisten" isOpen={true} onRequestClose={hideModal} type="ADVARSEL">
             <div className="modal-info-tekst blokk-s">
-                <Innholdstittel className="modal-info-tekst__overskrift blokk-s">Fjern fra arbeidsliste</Innholdstittel>
-                <Element className="blokk-m">{`${brukerSammensattNavn}, ${brukerFnr}`}</Element>
+                <Heading size="large" as="h1" className="modal-info-tekst__overskrift blokk-s">
+                    Fjern fra arbeidsliste
+                </Heading>
+                <BodyShort
+                    size="small"
+                    className="blokk-m"
+                    weight="semibold"
+                >{`${brukerSammensattNavn}, ${brukerFnr}`}</BodyShort>
             </div>
             <div className="knapper">
                 <Hovedknapp htmlType="submit" className="btn--mr1" onClick={handleSlettArbeidsListe}>

--- a/src/component/components/modal/modal-header.tsx
+++ b/src/component/components/modal/modal-header.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import { Innholdstittel } from 'nav-frontend-typografi';
+import { Heading } from '@navikt/ds-react';
 
 interface OwnProps {
     className?: string;
@@ -11,9 +11,9 @@ function ModalHeader({ className, tittel }: OwnProps) {
     return (
         <div className={classNames('modal-header-wrapper', className)}>
             <header className="modal-header">
-                <Innholdstittel tag="h1" className="modal-info-tekst__overskrift">
+                <Heading size="large" as="h1" className="modal-info-tekst__overskrift">
                     {tittel}
-                </Innholdstittel>
+                </Heading>
             </header>
         </div>
     );

--- a/src/component/personinfo/components/navnogalder.tsx
+++ b/src/component/personinfo/components/navnogalder.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Undertittel } from 'nav-frontend-typografi';
 import { Personalia } from '../../../api/veilarbperson';
 import { OrNothing } from '../../../util/type/utility-types';
+import { Heading } from '@navikt/ds-react';
 
 export function kalkulerAlder(fodselsdato: Date): number {
     const diff = Date.now() - fodselsdato.getTime();
@@ -18,7 +18,7 @@ export function lagAlderTekst(personalia: OrNothing<Personalia>): string {
 
 function NavnOgAlder(props: { personalia: OrNothing<Personalia>; navn: string }) {
     const alderTekst = lagAlderTekst(props.personalia);
-    return <Undertittel>{`${props.navn} ${alderTekst}`}</Undertittel>;
+    return <Heading size="small" as="h2">{`${props.navn} ${alderTekst}`}</Heading>;
 }
 
 export default NavnOgAlder;

--- a/src/component/veilederverktoy/avsluttoppfolging/avslutt-oppfolging-bekreft.tsx
+++ b/src/component/veilederverktoy/avsluttoppfolging/avslutt-oppfolging-bekreft.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Hovedknapp, Knapp } from 'nav-frontend-knapper';
 import { VarselModal } from '../../components/varselmodal/varsel-modal';
-import { Normaltekst } from 'nav-frontend-typografi';
 import { useModalStore } from '../../../store/modal-store';
 import { useDataStore } from '../../../store/data-store';
 import { selectSammensattNavn } from '../../../util/selectors';
 import { useAppStore } from '../../../store/app-store';
 import { avsluttOppfolging } from '../../../api/veilarboppfolging';
+import { BodyShort } from '@navikt/ds-react';
 
 export interface AvsluttOppfolgingBekreftelseModalProps {
     begrunnelse: string;
@@ -29,7 +29,7 @@ function AvsluttOppfolgingBekreft(props: AvsluttOppfolgingBekreftelseModalProps)
 
     return (
         <VarselModal contentLabel="Bruker kan ikke varsles" onRequestClose={hideModal} isOpen={true} type="ADVARSEL">
-            <Normaltekst>Er du sikker på at du vil avslutte oppfølgingsperioden til {brukerNavn}?</Normaltekst>
+            <BodyShort size="small">Er du sikker på at du vil avslutte oppfølgingsperioden til {brukerNavn}?</BodyShort>
             <div className="modal-footer">
                 <Hovedknapp
                     htmlType="submit"

--- a/src/component/veilederverktoy/avsluttoppfolging/components/avslutt-oppfolging-info-text.tsx
+++ b/src/component/veilederverktoy/avsluttoppfolging/components/avslutt-oppfolging-info-text.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import { Normaltekst } from 'nav-frontend-typografi';
 import { HiddenIfAlertStripeAdvarselSolid } from '../../../components/hidden-if/hidden-if-alertstripe';
 import NavFrontendSpinner from 'nav-frontend-spinner';
 import { fetchHarUtkast } from '../../../../api/veilarbvedtaksstotte';
@@ -7,6 +6,7 @@ import { AvslutningStatus } from '../../../../api/veilarboppfolging';
 import { fetchHarTiltak } from '../../../../api/veilarbaktivitet';
 import { useAxiosFetcher } from '../../../../util/hook/use-axios-fetcher';
 import { OrNothing } from '../../../../util/type/utility-types';
+import { BodyShort } from '@navikt/ds-react';
 
 export function AvsluttOppfolgingInfoText(props: {
     harYtelser?: boolean;
@@ -39,7 +39,7 @@ export function AvsluttOppfolgingInfoText(props: {
 
     return (
         <>
-            <Normaltekst>{aktivMindreEnn28Dager}</Normaltekst>
+            <BodyShort size="small">{aktivMindreEnn28Dager}</BodyShort>
             <HiddenIfAlertStripeAdvarselSolid hidden={!props.harUbehandledeDialoger && !harTiltak && !props.harYtelser}>
                 Du kan avslutte oppfølgingsperioden selv om:
                 <ul className="margin--0">

--- a/src/component/veilederverktoy/historikk/components/eskaleringsvarselHistorikk.tsx
+++ b/src/component/veilederverktoy/historikk/components/eskaleringsvarselHistorikk.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Element, Normaltekst, Undertekst } from 'nav-frontend-typografi';
 import { toSimpleDateStr } from '../../../../util/date-utils';
 import { EskaleringsvarselHistorikkInnslag } from '../../../../api/veilarbdialog';
 import LenkeTilDialog from '../../../components/dialoglenke/dialoglenke';
+import { BodyShort, Detail } from '@navikt/ds-react';
 
 interface EskaleringsvarselHistorikkKomponentProps {
     innslag: EskaleringsvarselHistorikkInnslag;
@@ -24,14 +24,16 @@ function EskaleringsvarselHistorikkKomponent({ innslag }: EskaleringsvarselHisto
 
     return (
         <div className="historikk__elem blokk-xs">
-            <Element>{overskrift}</Element>
-            <Normaltekst>
+            <BodyShort size="small" weight="semibold">
+                {overskrift}
+            </BodyShort>
+            <BodyShort size="small">
                 {begrunnelseTekst}
                 <LenkeTilDialog dialogId={innslag.tilhorendeDialogId}>Les mer i dialog</LenkeTilDialog>
-            </Normaltekst>
-            <Undertekst>{`${toSimpleDateStr(dato)} av ${utfortAv}${
+            </BodyShort>
+            <Detail>{`${toSimpleDateStr(dato)} av ${utfortAv}${
                 utfortAvBrukerNavn ? ` (${utfortAvBrukerNavn})` : ''
-            }`}</Undertekst>
+            }`}</Detail>
         </div>
     );
 }

--- a/src/component/veilederverktoy/historikk/components/innstillingshistorikk.tsx
+++ b/src/component/veilederverktoy/historikk/components/innstillingshistorikk.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Element, Normaltekst, Undertekst } from 'nav-frontend-typografi';
 import { opprettetAvTekst } from './opprettet-av';
 import { toSimpleDateStr } from '../../../../util/date-utils';
 import { InnstillingHistorikkInnslag } from '../../../../api/veilarboppfolging';
 import LenkeTilDialog from '../../../components/dialoglenke/dialoglenke';
+import { BodyShort, Detail } from '@navikt/ds-react';
 
 interface InnstillingHistorikkKomponentProps {
     innstillingsHistorikk: InnstillingHistorikkInnslag;
@@ -32,18 +32,18 @@ function InnstillingHistorikkKomponent({ innstillingsHistorikk }: InnstillingHis
 
     return (
         <div className="historikk__elem blokk-xs">
-            <Element>{typeTilTekst[type]}</Element>
-            <Normaltekst>
+            <BodyShort size="small" weight="semibold">
+                {typeTilTekst[type]}
+            </BodyShort>
+            <BodyShort size="small">
                 {begrunnelseTekst}
                 {dialogId && <LenkeTilDialog dialogId={dialogId}>Les mer i dialog</LenkeTilDialog>}
-            </Normaltekst>
-            <Undertekst>
-                {`${toSimpleDateStr(innstillingsHistorikk.dato)} ${opprettetAvTekst(
-                    innstillingsHistorikk.opprettetAv,
-                    innstillingsHistorikk.opprettetAvBrukerId || '',
-                    innstillingsHistorikk.opprettetAvBrukerNavn
-                )}`}
-            </Undertekst>
+            </BodyShort>
+            <Detail>{`${toSimpleDateStr(innstillingsHistorikk.dato)} ${opprettetAvTekst(
+                innstillingsHistorikk.opprettetAv,
+                innstillingsHistorikk.opprettetAvBrukerId || '',
+                innstillingsHistorikk.opprettetAvBrukerNavn
+            )}`}</Detail>
         </div>
     );
 }

--- a/src/component/veilederverktoy/historikk/components/oppfolgingEndret.tsx
+++ b/src/component/veilederverktoy/historikk/components/oppfolgingEndret.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect } from 'react';
 import NavFrontendSpinner from 'nav-frontend-spinner';
-import { Element, Normaltekst, Undertekst } from 'nav-frontend-typografi';
 import { opprettetAvTekst } from './opprettet-av';
-import { Alert } from '@navikt/ds-react';
+import { Alert, BodyShort, Detail } from '@navikt/ds-react';
 import { hasAnyFailed, isAnyLoading } from '../../../../api/utils';
 import { toSimpleDateStr } from '../../../../util/date-utils';
 import { InnstillingHistorikkInnslag } from '../../../../api/veilarboppfolging';
@@ -39,11 +38,11 @@ export function OppfolgingEnhetEndret(props: {
 
     return (
         <div className="historikk__elem blokk-xs" key={dato}>
-            <Element>{props.erGjeldendeEnhet ? 'Gjeldende oppfølgingsenhet' : 'Oppfølgingsenhet endret'}</Element>
-            <Normaltekst>{begrunnelseTekst}</Normaltekst>
-            <Undertekst>
-                {`${toSimpleDateStr(dato)} ${opprettetAvTekst(opprettetAv, opprettetAvBrukerId || '')}`}
-            </Undertekst>
+            <BodyShort size="small" weight="semibold">
+                {props.erGjeldendeEnhet ? 'Gjeldende oppfølgingsenhet' : 'Oppfølgingsenhet endret'}
+            </BodyShort>
+            <BodyShort size="small">{begrunnelseTekst}</BodyShort>
+            <Detail>{`${toSimpleDateStr(dato)} ${opprettetAvTekst(opprettetAv, opprettetAvBrukerId || '')}`}</Detail>
         </div>
     );
 }

--- a/src/component/veilederverktoy/historikk/components/oppgavehistorikk.tsx
+++ b/src/component/veilederverktoy/historikk/components/oppgavehistorikk.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Element, Normaltekst, Undertekst } from 'nav-frontend-typografi';
 import { opprettetAvTekst } from './opprettet-av';
 import { toSimpleDateStr } from '../../../../util/date-utils';
 import { OppgaveHistorikkInnslag } from '../../../../api/veilarboppgave';
+import { BodyShort, Detail } from '@navikt/ds-react';
 
 interface OwnProps {
     oppgaveHistorikk: OppgaveHistorikkInnslag;
@@ -26,17 +26,15 @@ function OppgaveHistorikkKomponent({ oppgaveHistorikk }: OwnProps) {
     const { oppgaveTema, oppgaveType } = oppgaveHistorikk;
     return (
         <div className="historikk__elem blokk-xs">
-            <Element>Gosys-oppgave opprettet</Element>
-            <Normaltekst>
-                {`Oppgave med tema ${oppgaveTemaTekst[oppgaveTema]} og type ${oppgaveTypetekst[oppgaveType]} opprettet`}
-            </Normaltekst>
-            <Undertekst>
-                {`${toSimpleDateStr(oppgaveHistorikk.dato)} ${opprettetAvTekst(
-                    oppgaveHistorikk.opprettetAv,
-                    oppgaveHistorikk.opprettetAvBrukerId,
-                    oppgaveHistorikk.opprettetAvBrukerNavn
-                )}`}
-            </Undertekst>
+            <BodyShort size="small" weight="semibold">
+                Gosys-oppgave opprettet
+            </BodyShort>
+            <BodyShort size="small">{`Oppgave med tema ${oppgaveTemaTekst[oppgaveTema]} og type ${oppgaveTypetekst[oppgaveType]} opprettet`}</BodyShort>
+            <Detail>{`${toSimpleDateStr(oppgaveHistorikk.dato)} ${opprettetAvTekst(
+                oppgaveHistorikk.opprettetAv,
+                oppgaveHistorikk.opprettetAvBrukerId,
+                oppgaveHistorikk.opprettetAvBrukerNavn
+            )}`}</Detail>
         </div>
     );
 }

--- a/src/component/veilederverktoy/historikk/historikk-visning.tsx
+++ b/src/component/veilederverktoy/historikk/historikk-visning.tsx
@@ -1,13 +1,13 @@
 import OppgaveHistorikkKomponent from './components/oppgavehistorikk';
 import InnstillingsHistorikkKomponent from './components/innstillingshistorikk';
 import React from 'react';
-import { Normaltekst } from 'nav-frontend-typografi';
 import { OppfolgingEnhetEndret } from './components/oppfolgingEndret';
 import dayjs from 'dayjs';
 import { InnstillingHistorikkInnslag } from '../../../api/veilarboppfolging';
 import { OppgaveHistorikkInnslag } from '../../../api/veilarboppgave';
 import { EskaleringsvarselHistorikkInnslag } from '../../../api/veilarbdialog';
 import EskaleringsvarselHistorikkKomponent from './components/eskaleringsvarselHistorikk';
+import { BodyShort } from '@navikt/ds-react';
 
 type Historikk = InnstillingHistorikk | OppgaveHistorikk | EskaleringsvarselHistorikk;
 
@@ -111,7 +111,7 @@ function HistorikkVisning({
     );
 
     if (historikk.length === 0) {
-        return <Normaltekst> Ingen historikk </Normaltekst>;
+        return <BodyShort size="small">Ingen historikk</BodyShort>;
     }
 
     if (historikk.length === 1) {

--- a/src/component/veilederverktoy/opprett-oppgave/opprett-oppgave.tsx
+++ b/src/component/veilederverktoy/opprett-oppgave/opprett-oppgave.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Form } from 'formik';
-import { Undertittel } from 'nav-frontend-typografi';
 import OpprettOppgaveTemaSelector from './components/opprett-oppgave-tema-selector';
 import OppgaveInnerForm from './components/oppgave-inner-form';
 import FormikModal from '../../components/formik/formik-modal';
@@ -12,6 +11,7 @@ import './opprett-oppgave.less';
 import { todayReversedDateStr } from '../../../util/date-utils';
 import { OppgaveFormData, OppgaveTema, OppgaveType, opprettOppgave, PrioritetType } from '../../../api/veilarboppgave';
 import { OrNothing, StringOrNothing } from '../../../util/type/utility-types';
+import { Heading } from '@navikt/ds-react';
 
 export interface OpprettOppgaveFormValues {
     beskrivelse: string;
@@ -45,6 +45,7 @@ function OpprettOppgave() {
         veilederId: null,
         avsenderenhetId: enhetId
     };
+
     function lagreOppgave(formdata: OppgaveFormData) {
         showSpinnerModal();
 
@@ -54,6 +55,7 @@ function OpprettOppgave() {
             })
             .catch(showErrorModal);
     }
+
     if (!enhetId) {
         return null;
     }
@@ -67,7 +69,11 @@ function OpprettOppgave() {
             className="opprett-oppgave"
             render={formikProps => (
                 <div className="modal-innhold">
-                    <Undertittel className="opprett-oppgave__undertittel">{`Oppfølging av ${navn}`}</Undertittel>
+                    <Heading
+                        size="small"
+                        as="h2"
+                        className="opprett-oppgave__undertittel"
+                    >{`Oppfølging av ${navn}`}</Heading>
                     <Form>
                         <OpprettOppgaveTemaSelector />
                         <OppgaveInnerForm

--- a/src/component/veilederverktoy/prosess/kvittering.tsx
+++ b/src/component/veilederverktoy/prosess/kvittering.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Normaltekst, Systemtittel } from 'nav-frontend-typografi';
 import { VarselModal } from '../../components/varselmodal/varsel-modal';
 import { useModalStore } from '../../../store/modal-store';
+import { BodyShort, Heading } from '@navikt/ds-react';
 
 interface KvitteringProps {
     tittel: string;
@@ -26,9 +26,13 @@ function Kvittering({ tittel, alertStripeTekst, footer, onRequestClose }: Kvitte
             type="SUCCESS"
         >
             <div className="blokk-xs">
-                <Systemtittel className="modal-info-tekst__undertekst blokk-xs">{tittel}</Systemtittel>
-                <Normaltekst className="blokk-xs">{alertStripeTekst}</Normaltekst>
-                {!!footer && <div className="kvittering-footer">{footer}</div>}
+                <Heading size="medium" as="h2" className="modal-info-tekst__undertekst blokk-xs">
+                    {tittel}
+                </Heading>
+                <BodyShort className="blokk-xs" size="small">
+                    {alertStripeTekst}
+                </BodyShort>
+                {!!footer && <BodyShort size="medium">{footer}</BodyShort>}
             </div>
         </VarselModal>
     );

--- a/src/component/veilederverktoy/start-digital-oppfolging/start-digital-oppfolging.tsx
+++ b/src/component/veilederverktoy/start-digital-oppfolging/start-digital-oppfolging.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import BegrunnelseForm, { BegrunnelseValues } from '../begrunnelseform/begrunnelse-form';
-import { Alert } from '@navikt/ds-react';
+import { Alert, BodyShort } from '@navikt/ds-react';
 import { VarselModal } from '../../components/varselmodal/varsel-modal';
-import { Normaltekst } from 'nav-frontend-typografi';
 import { useAppStore } from '../../../store/app-store';
 import { useDataStore } from '../../../store/data-store';
 import { useModalStore } from '../../../store/modal-store';
@@ -36,10 +35,10 @@ function StartDigitalOppfolging() {
                 isOpen={true}
                 onRequestClose={hideModal}
             >
-                <Normaltekst>
+                <BodyShort size="small">
                     Brukeren er reservert i Kontakt- og reservasjonsregisteret og må selv fjerne reservasjonen for å få
                     digital oppfølging.
-                </Normaltekst>
+                </BodyShort>
             </VarselModal>
         );
     }

--- a/src/component/veilederverktoy/start-eskalering/start-eskalering.tsx
+++ b/src/component/veilederverktoy/start-eskalering/start-eskalering.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import { Normaltekst } from 'nav-frontend-typografi';
 import { VarselModal } from '../../components/varselmodal/varsel-modal';
 import StartEskaleringForm, { StartEskaleringValues } from './start-eskalering-form';
 import { useModalStore } from '../../../store/modal-store';
@@ -11,6 +10,7 @@ import { LasterModal } from '../../components/lastermodal/laster-modal';
 import { useAxiosFetcher } from '../../../util/hook/use-axios-fetcher';
 import { fetchHarNivaa4 } from '../../../api/veilarbperson';
 import { logMetrikk } from '../../../util/logger';
+import { BodyShort } from '@navikt/ds-react';
 
 interface OwnValues extends StartEskaleringValues {
     overskrift: string;
@@ -100,15 +100,15 @@ function StartEskalering() {
             isLoading={false}
             infoTekst={
                 <>
-                    <Normaltekst className="blokk-xs">
+                    <BodyShort size="small" className="blokk-xs">
                         Når du sender forhåndsvarsel må du huske å være tydelig på hvilken oppgave som skal gjennomføre,
                         og hvilken frist personen får for tilbakemelding. Personen får en brukernotifikasjon på ditt nav
                         med teksten: Viktig oppgave. NAV vurderer å stanse pengene dine. Se hva du må gjøre.
-                    </Normaltekst>
-                    <Normaltekst className="blokk-xs">
+                    </BodyShort>
+                    <BodyShort size="small" className="blokk-xs">
                         Ved å klikke på brukernotifikasjon, kommer personen direkte inn i riktig dialog der
                         forhåndsvarslet ligger.
-                    </Normaltekst>
+                    </BodyShort>
                 </>
             }
         />

--- a/src/component/veilederverktoy/start-kvp-periode/start-kvp-periode.tsx
+++ b/src/component/veilederverktoy/start-kvp-periode/start-kvp-periode.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import BegrunnelseForm, { BegrunnelseValues } from '../begrunnelseform/begrunnelse-form';
-import { Normaltekst } from 'nav-frontend-typografi';
 import { useModalStore } from '../../../store/modal-store';
 import { useAppStore } from '../../../store/app-store';
 import { fetchOppfolging, startKvpOppfolging } from '../../../api/veilarboppfolging';
 import { ifResponseHasData } from '../../../util/utils';
 import { useDataStore } from '../../../store/data-store';
+import { BodyShort } from '@navikt/ds-react';
 
 function StarKvpPeriode() {
     const { brukerFnr } = useAppStore();
@@ -25,10 +25,10 @@ function StarKvpPeriode() {
     }
 
     const infoTekst = (
-        <Normaltekst className="blokk-xs">
+        <BodyShort size="small" className="blokk-xs">
             Når du klikker «Bekreft» vil bare veiledere i din enhet ha tilgang på dialoger, aktiviteter og mål som blir
             opprettet i KVP-perioden. Du må skrive en kommentar før du bekrefter.
-        </Normaltekst>
+        </BodyShort>
     );
 
     const initialValues = { begrunnelse: '' };

--- a/src/component/veilederverktoy/stopp-eskalering/stopp-eskalering.tsx
+++ b/src/component/veilederverktoy/stopp-eskalering/stopp-eskalering.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import FormikModal from '../../components/formik/formik-modal';
-import { Normaltekst } from 'nav-frontend-typografi';
 import { Form } from 'formik';
 import FormikCheckBox from '../../components/formik/formik-checkbox';
 import BegrunnelseFooter from '../begrunnelseform/begrunnelse-form-footer';
@@ -11,6 +10,7 @@ import { useDataStore } from '../../../store/data-store';
 import { eskaleringVarselSendtEvent } from '../../../util/utils';
 import { stopEskalering } from '../../../api/veilarbdialog';
 import './stopp-eskalering.less';
+import { BodyShort } from '@navikt/ds-react';
 
 interface FormValues {
     begrunnelse: string;
@@ -64,9 +64,9 @@ function StoppEskalering() {
                             <FormikCheckBox name="skalSendeHendelse" label={'Send bruker en henvendelse'} />
                             {formikProps.values.skalSendeHendelse && (
                                 <>
-                                    <Normaltekst className="stopp-eskalering__tekst">
+                                    <BodyShort size="small" className="stopp-eskalering__tekst">
                                         Legg inn eller rediger tekst som du sender til brukeren.
-                                    </Normaltekst>
+                                    </BodyShort>
                                     <BegrunnelseTextArea
                                         tekstariaLabel="Se eksempel på tekst til brukeren under:"
                                         maxLength={500}

--- a/src/component/veilederverktoy/stopp-kvp-periode/stopp-kvp-periode.tsx
+++ b/src/component/veilederverktoy/stopp-kvp-periode/stopp-kvp-periode.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import BegrunnelseForm, { BegrunnelseValues } from '../begrunnelseform/begrunnelse-form';
-import { Normaltekst } from 'nav-frontend-typografi';
 import { useAppStore } from '../../../store/app-store';
 import { useModalStore } from '../../../store/modal-store';
 import { fetchOppfolging, stoppKvpOppfolging } from '../../../api/veilarboppfolging';
 import { ifResponseHasData } from '../../../util/utils';
 import { useDataStore } from '../../../store/data-store';
+import { BodyShort } from '@navikt/ds-react';
 
 const initialValues = { begrunnelse: '' };
 
@@ -15,10 +15,10 @@ function StoppKvpPeriode() {
     const { showStoppKvpPeriodeKvitteringModal, showSpinnerModal, showErrorModal } = useModalStore();
 
     const infoTekst = (
-        <Normaltekst className="blokk-xs">
+        <BodyShort size="small" className="blokk-xs">
             KVP-perioden til brukeren er avsluttet. Veiledere i andre enheter har nå tilgang til dialoger, aktiviteter
             og mål som er opprettet før og etter KVP-perioden.
-        </Normaltekst>
+        </BodyShort>
     );
 
     function stoppKvp({ begrunnelse }: BegrunnelseValues) {

--- a/src/component/veilederverktoy/tildel-veileder/tildel-veileder-feil-modal.tsx
+++ b/src/component/veilederverktoy/tildel-veileder/tildel-veileder-feil-modal.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { VarselModal } from '../../components/varselmodal/varsel-modal';
-import { Normaltekst, Systemtittel } from 'nav-frontend-typografi';
 import { logMetrikk } from '../../../util/logger';
 import { useModalStore } from '../../../store/modal-store';
+import { BodyShort, Heading } from '@navikt/ds-react';
 
 export function FeilTildelingModal() {
     const { hideModal } = useModalStore();
@@ -20,11 +20,13 @@ export function FeilTildelingModal() {
             type="FEIL"
             onRequestClose={lukkModal}
         >
-            <Systemtittel>Handlingen kan ikke utføres</Systemtittel>
-            <Normaltekst className="feil-modal-normaltekst">
+            <Heading size="medium" as="h2">
+                Handlingen kan ikke utføres
+            </Heading>
+            <BodyShort size="small" className="feil-modal-normaltekst">
                 Tildeling av veileder feilet. Det kan skyldes manglende tilgang til brukeren, at veilederen allerede er
                 tildelt brukeren, eller at brukeren ikke er under oppfølging.
-            </Normaltekst>
+            </BodyShort>
             <button className="knapp knapp--hoved feil-modal-knapp" onClick={lukkModal}>
                 Ok
             </button>

--- a/src/component/veilederverktoy/tildel-veileder/tildel-veileder-kvittering.tsx
+++ b/src/component/veilederverktoy/tildel-veileder/tildel-veileder-kvittering.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { VarselModal } from '../../components/varselmodal/varsel-modal';
-import { Innholdstittel, Normaltekst } from 'nav-frontend-typografi';
 import { useModalStore } from '../../../store/modal-store';
+import { BodyShort, Heading } from '@navikt/ds-react';
 
 export interface TildelVeilederKvitteringProps {
     tildeltVeilederNavn: string;
@@ -12,10 +12,12 @@ export function TildelVeilederKvittering(props: TildelVeilederKvitteringProps) {
 
     return (
         <VarselModal isOpen={true} onRequestClose={hideModal} contentLabel="Vellykket tildeling" type="SUCCESS">
-            <Innholdstittel>Tildel veileder</Innholdstittel>
-            <Normaltekst>
+            <Heading size="large" as="h1">
+                Tildel veileder
+            </Heading>
+            <BodyShort size="small">
                 Du har tildelt veileder {props.tildeltVeilederNavn}. Det kan ta noe tid før brukeren er i Min oversikt.
-            </Normaltekst>
+            </BodyShort>
         </VarselModal>
     );
 }

--- a/src/mock/api/veilarbportefolje.ts
+++ b/src/mock/api/veilarbportefolje.ts
@@ -4,13 +4,13 @@ import { delay, http, HttpResponse, RequestHandler } from 'msw';
 
 const mockArbeidsliste: Arbeidsliste = {
     arbeidslisteAktiv: null,
-    endringstidspunkt: null,
+    endringstidspunkt: new Date(),
     frist: null,
     harVeilederTilgang: true,
     isOppfolgendeVeileder: true,
     kommentar: null,
     overskrift: null,
-    sistEndretAv: null,
+    sistEndretAv: {veilederId: "Z123456"},
     kategori: KategoriModell.GRONN
 };
 


### PR DESCRIPTION
Bytter til nytt designsystem for alle typografi komponentene vi har.

Kan ikke fjerne selve `nav-frontend-typografi`/`nav-frontend-typografi-style` avhengighetene helt ennå siden vi har andre avhengigheter som har dem som transitive avhengigheter.