### PR TITLE
Fikse styling-bug for dropdown-knapper i "Opprett Gosys-oppgave"-modal

### DIFF
--- a/src/component/components/dropdown/dropdown.tsx
+++ b/src/component/components/dropdown/dropdown.tsx
@@ -69,7 +69,7 @@ function Dropdown(props: DropdownProps) {
         <div className="dropdown">
             <div className={btnCls(apen, className)} ref={loggNode}>
                 <Button
-                    variant="tertiary"
+                    variant="tertiary-neutral"
                     icon={<TannHjulIkon className="knapp-fss__icon" />}
                     ref={btnRef}
                     className={classNames('dropdown__btn', props.btnClassnames)}

--- a/src/component/components/meny-knapp/meny-knapp.less
+++ b/src/component/components/meny-knapp/meny-knapp.less
@@ -11,6 +11,7 @@
         height: 2.5rem;
         justify-content: left;
     }
+
     .meny-knapp:hover {
         background-color: @navMorkGra;
         color: white;

--- a/src/component/veilederverktoy/opprett-oppgave/components/opprett-oppgave-veileder-selector.tsx
+++ b/src/component/veilederverktoy/opprett-oppgave/components/opprett-oppgave-veileder-selector.tsx
@@ -57,7 +57,7 @@ function OpprettOppgaveVelgVeileder({ veilederId, tema, formikProps, enhetId }: 
             <Dropdown
                 name="Velg veileder dropdown"
                 knappeTekst={(valgtVeileder && valgtVeileder.navn) || ''}
-                className="skjemaelement velg-enhet-dropdown"
+                className="velg-enhet-dropdown"
                 btnClassnames="velg-enhet-dropdown__button"
                 render={lukkDropdown => (
                     <SokFilter data={sorterteVeiledere} label="" placeholder="Søk etter veileder">

--- a/src/component/veilederverktoy/opprett-oppgave/opprett-oppgave.less
+++ b/src/component/veilederverktoy/opprett-oppgave/opprett-oppgave.less
@@ -86,14 +86,12 @@
             background: #3e3832;
         }
     }
-}
 
-// TODO: Dette er en midlertidig workaround mens vi holder på å skrive oss over til nytt designsystem
-// Klassene under overrider styling fra navds-button/navds-label ved at vi "vinner" på CSS-spesifisitet.
-// Grunnen til overridene er at vi per dags dato har en egenutviklet dropdown-komponent.
-// Denne skal byttes ut med Dropdown/Combobox fra nytt designsystem, men inntil videre
-// må vi override noen få styles da vi allerede har tatt i bruk Button fra nytt designsystem.
-.velg-enhet-dropdown {
+    // TODO: Dette er en midlertidig workaround mens vi holder på å skrive oss over til nytt designsystem
+    // CSS-reglene under her overstyrer styling fra navds-button/navds-label ved at vi "vinner" på CSS-spesifisitet.
+    // Grunnen til overridene er at vi per dags dato har en egenutviklet dropdown-komponent.
+    // Denne skal byttes ut med Dropdown/Combobox fra nytt designsystem, men inntil videre
+    // må vi override noen få styles da vi allerede har tatt i bruk Button fra nytt designsystem.
     &__button.navds-button {
         justify-content: left;
     }

--- a/src/component/veilederverktoy/opprett-oppgave/opprett-oppgave.less
+++ b/src/component/veilederverktoy/opprett-oppgave/opprett-oppgave.less
@@ -87,3 +87,63 @@
         }
     }
 }
+
+// TODO: Dette er en midlertidig workaround mens vi holder på å skrive oss over til nytt designsystem
+// Klassene under overrider styling fra navds-button/navds-label ved at vi "vinner" på CSS-spesifisitet.
+// Grunnen til overridene er at vi per dags dato har en egenutviklet dropdown-komponent.
+// Denne skal byttes ut med Dropdown/Combobox fra nytt designsystem, men inntil videre
+// må vi override noen få styles da vi allerede har tatt i bruk Button fra nytt designsystem.
+.velg-enhet-dropdown {
+    &__button.navds-button {
+        justify-content: left;
+    }
+
+    &__button .navds-label {
+        font-weight: normal;
+        font-size: 1rem;
+    }
+
+    &__button.navds-button {
+        border-radius: 4px;
+        text-align: left;
+        border: 1px solid #78706a;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    &__button.navds-button:hover {
+        border: 1px solid #0067c5;
+        color: #3e3832;
+    }
+
+    &__button.navds-button:focus {
+        outline: 0;
+        box-shadow: 0 0 0 3px @fokusFarge;
+    }
+
+    .dropdown {
+        &__btn.navds-button {
+            width: inherit;
+            height: inherit;
+            padding: 0.45rem;
+            background-color: white;
+        }
+
+        &__btn.navds-button:hover {
+            color: #3e3832;
+        }
+
+        &__btn.navds-button:hover:after {
+            background: #3e3832;
+        }
+
+        &__btn.navds-button:hover:before {
+            background: #3e3832;
+        }
+
+        &__btn:active:hover {
+            background-color: white;
+        }
+    }
+}


### PR DESCRIPTION
Vi hadde en bug i stylingen av dropdown-knappene inne i "Opprett Gosys-oppgave"-modalen (se vedlagt video).

Jeg prøver å røre så lite som mulig her og lar eventuelle andre forbedringer være til når resten av teamet er tilbake. 

Jeg valgte å overstyre nødvendige `navds-*`-klasser for å få et utseende som er likt det som var før vi begynte å bruke den nye `Button`-komponenten. Dette oppnår jeg ved å være "mer" spesifikk når det kommer til [CSS specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity). Ikke akkurat den mest bærekraftige løsningen, men jeg la igjen en ganske tydelig kommentar. Dessuten skal vi over på `Dropdown`/`Combobox`-komponenter fra nytt designsystem, så dette er bare midlertidig.

---

Før:

https://github.com/navikt/veilarbvisittkortfs/assets/111113539/896d9fbd-36e3-45ab-bfce-60e0f634fa26

Etter:

https://github.com/navikt/veilarbvisittkortfs/assets/111113539/6f5f9a1c-2be8-4d29-b1a7-5b02eb8151c6