### PR TITLE
Overstyrer styling som blør ut frå vedtaksstøttefs

### DIFF
--- a/src/component/components/formik/formik.less
+++ b/src/component/components/formik/formik.less
@@ -1,11 +1,20 @@
-.formik-input {
-    margin-top: 1rem;
-    width: 40%;
-}
-.formik-textarea {
-    margin-top: 1rem;
-    max-width: 66ch;
-}
-.formik-select {
-    width: fit-content;
+.visittkortfs, .visittkortfs-modal {
+    .formik-input {
+        margin-top: 1rem;
+        width: 40%;
+    }
+
+    .formik-textarea {
+        margin-top: 1rem;
+        max-width: 66ch;
+
+        // Midlertidig fiks som motvirkar 'position: absolute;' frå vedtaksstøttefs. 2024-01-09
+        .navds-textarea__counter {
+            position: inherit;
+        }
+    }
+
+    .formik-select {
+        width: fit-content;
+    }
 }


### PR DESCRIPTION
Overstyrer styling som blør ut frå vedtaksstøttefs for teksten "[tall] tegn igjen" i text-area