### PR TITLE
Fiksar bygging til github pages

### DIFF
--- a/.github/workflows/deploy-dev-gcp.yaml
+++ b/.github/workflows/deploy-dev-gcp.yaml
@@ -21,7 +21,7 @@ jobs:
                   node-version: 20
                   cache: npm
             - name: Install dependencies
-              run: npm ci --legacy-peer-deps
+              run: npm ci
             - name: Run tests
               run: npm run test
             - name: Build application

--- a/.github/workflows/depoloy-prod-gcp.yaml
+++ b/.github/workflows/depoloy-prod-gcp.yaml
@@ -23,7 +23,7 @@ jobs:
                   node-version: 20
                   cache: npm
             - name: Install dependencies
-              run: npm ci --legacy-peer-deps
+              run: npm ci
             - name: Run tests
               run: npm run test
             - name: Build application

--- a/.github/workflows/update-github-pages.yaml
+++ b/.github/workflows/update-github-pages.yaml
@@ -23,6 +23,8 @@ jobs:
               run: npm ci --legacy-peer-deps
             - name: Build mock application
               run: npm run build:mock
+              env:
+                PUBLIC_URL: /veilarbvisittkortfs
             - name: Update GitHub pages
               uses: softprops/action-gh-release@v1
               with:

--- a/.github/workflows/update-github-pages.yaml
+++ b/.github/workflows/update-github-pages.yaml
@@ -6,7 +6,6 @@ on:
             - master
 permissions:
   contents: write
-  pages: write
 jobs:
     update-gh-pages:
         name: Update GitHub pages
@@ -26,8 +25,7 @@ jobs:
               env:
                 PUBLIC_URL: /veilarbvisittkortfs
             - name: Update GitHub pages
-              uses: softprops/action-gh-release@v1
+              uses: peaceiris/actions-gh-pages@v3
               with:
-                  tag_name: github_pages
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
                   publish_dir: ./build

--- a/.github/workflows/update-github-pages.yaml
+++ b/.github/workflows/update-github-pages.yaml
@@ -19,7 +19,7 @@ jobs:
                   node-version: '20'
                   cache: 'npm'
             - name: Install dependencies
-              run: npm ci --legacy-peer-deps
+              run: npm ci
             - name: Build mock application
               run: npm run build:mock
               env:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "start": "vite",
         "build": "tsc && vite build",
         "build:dev": "tsc && NODE_ENV=development vite build",
-        "build:mock": "tsc && NODE_MODE=mock vite build",
+        "build:mock": "tsc && vite build --mode mock",
         "serve": "vite preview",
         "test": "echo not implemented",
         "prettier": "prettier --write 'src/**/*.ts{,x}'",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "start": "vite",
         "build": "tsc && vite build",
         "build:dev": "tsc && NODE_ENV=development vite build",
+        "build:mock": "tsc && NODE_MODE=mock vite build",
         "serve": "vite preview",
         "test": "echo not implemented",
         "prettier": "prettier --write 'src/**/*.ts{,x}'",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "module",
     "private": true,
     "scripts": {
-        "start": "vite",
+        "start": "vite --mode mock",
         "build": "tsc && vite build",
         "build:dev": "tsc && NODE_ENV=development vite build",
         "build:mock": "tsc && vite build --mode mock",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,8 @@ if (isLocalDevelopment()) {
                 root.render(
                     <App fnr={'10108000398'} enhet={'1234'} tilbakeTilFlate={''} visVeilederVerktoy={true} />
                 );
+                // eslint-disable-next-line no-console
+                console.log('Bruker mock-data i applikasjonen');
             }
         )
         .catch((e: Error) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,23 +11,24 @@ dayjs.locale('nb');
 Navspa.eksporter('veilarbvisittkortfs', App);
 
 if (isLocalDevelopment()) {
-    const { worker } = await import('./mock');
     const container = document.getElementById('veilarbvisittkortfs-root');
     const root = createRoot(container!);
 
-    worker.start()
-        .then(() => {
-                root.render(
-                    <App fnr={'10108000398'} enhet={'1234'} tilbakeTilFlate={''} visVeilederVerktoy={true} />
-                );
+    import('./mock').then(({ worker }) => {
+        return worker.start()
+            .then(() => {
+                    root.render(
+                        <App fnr={'10108000398'} enhet={'1234'} tilbakeTilFlate={''} visVeilederVerktoy={true} />
+                    );
+                    // eslint-disable-next-line no-console
+                    console.log('Bruker mock-data i applikasjonen');
+                }
+            )
+            .catch((e: Error) => {
                 // eslint-disable-next-line no-console
-                console.log('Bruker mock-data i applikasjonen');
-            }
-        )
-        .catch((e: Error) => {
-            // eslint-disable-next-line no-console
-            console.error('Unable to setup mocked API endpoints', e);
-        });
+                console.error('Unable to setup mocked API endpoints', e);
+            });
+    });
 } else {
     initAmplitude();
 }

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -12,7 +12,7 @@ export function visEmdashHvisNull(verdi: StringOrNothing) {
 export const APP_NAME = 'veilarbvisittkortfs';
 
 export function isLocalDevelopment(): boolean {
-    return import.meta.env.DEV;
+    return import.meta.env.MODE === "mock";
 }
 
 export const erProd = () => (import.meta.env.PROD);


### PR DESCRIPTION
- Lagt til script for å byggje med mocking
- Slutta å bruke top-level await 
- Teke i bruk rett action for GitHub Pages
- Installerar no "vanleg" (`npm ci`) i staden for med `--legacy-peer-deps` i GitHub Actions