### PR TITLE
Oppdaterer @navikt (designsystemet) frå v5.12.1 til v5.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
             "version": "0.1.0",
             "dependencies": {
                 "@amplitude/analytics-browser": "2.3.2",
-                "@navikt/aksel-icons": "5.12.1",
-                "@navikt/ds-css": "5.12.1",
+                "@navikt/aksel-icons": "5.18.0",
+                "@navikt/ds-css": "5.18.0",
                 "@navikt/ds-css-internal": "3.4.3",
-                "@navikt/ds-react": "5.12.1",
+                "@navikt/ds-react": "5.18.0",
                 "@navikt/fnrvalidator": "^1.1.3",
                 "@navikt/navspa": "^5.0.1",
                 "axios": "^1.6.7",
@@ -1118,14 +1118,14 @@
             }
         },
         "node_modules/@navikt/aksel-icons": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@navikt/aksel-icons/-/aksel-icons-5.12.1.tgz",
-            "integrity": "sha512-4L0dARUYII+cQONZyNv5sZhZPdK0GaVtW0hw0LVQB1yzmOVQL2mGOf12jxUbMkAwKAwa1eroEAeaPVgzjpb2Ww=="
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@navikt/aksel-icons/-/aksel-icons-5.18.0.tgz",
+            "integrity": "sha512-upFPrvJLz0PbgDMqbUa/U2pj8hjUpEE+frw+3KwCvpwC8/N0yfAaK1iqBxfPw5tn8dSJ+M1UJAdDvnMnb9pNBw=="
         },
         "node_modules/@navikt/ds-css": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-5.12.1.tgz",
-            "integrity": "sha512-3lkNLgDW1h4RjcDgmlqb5ELOgYPuH3HhXaQM/kAmMy0T4bsbDDANhl1o7cC+fcmDrgaayfnn05uMRXtPblQqBA=="
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-5.18.0.tgz",
+            "integrity": "sha512-69cOjIPtfgGqBPk/qmP/ifnVQk9hkvg8g4S0VRjzRQP1EgqOx775Vhoe7L22oRDbE0I8lViRHBZuspcsMBZPUg=="
         },
         "node_modules/@navikt/ds-css-internal": {
             "version": "3.4.3",
@@ -1133,13 +1133,13 @@
             "integrity": "sha512-VusM4uwHZoQWiX8N/1zD6ycgNFIzYQ40TXhlP7tqpdH6sVwwzFPWCWXaZtpyjUfHxU9WyNEDYoeRAECkC0qfzg=="
         },
         "node_modules/@navikt/ds-react": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-5.12.1.tgz",
-            "integrity": "sha512-6CwV66IwRuGxtJ1HAr18kTa3kVA4+T6pKHbHXRJkJZN2ELVk1306/zoOzHzyiuShvmEISoTH3X+na0DMRgNG1A==",
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-5.18.0.tgz",
+            "integrity": "sha512-jT4LiUzxRwCVUW1YIu5DKd0C8IY8k7ICwIZpjCINETJ6XIP2EtA8E8QP6wSkSbHqhtMuIuVGdRba9rWUew4Lqw==",
             "dependencies": {
                 "@floating-ui/react": "0.25.4",
-                "@navikt/aksel-icons": "^5.12.1",
-                "@navikt/ds-tokens": "^5.12.1",
+                "@navikt/aksel-icons": "^5.18.0",
+                "@navikt/ds-tokens": "^5.18.0",
                 "@radix-ui/react-tabs": "1.0.0",
                 "@radix-ui/react-toggle-group": "1.0.0",
                 "clsx": "^1.2.1",
@@ -1185,9 +1185,9 @@
             }
         },
         "node_modules/@navikt/ds-tokens": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-tokens/-/ds-tokens-5.12.1.tgz",
-            "integrity": "sha512-oM2bXHPxhz6LW4qEFF1O+vTDBw3xZxZV2RLnMK3qQHqCWsTjb4AW4mq+4DW19KyYXV5e2vrPMqOjbv4qnNDj9A=="
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-tokens/-/ds-tokens-5.18.0.tgz",
+            "integrity": "sha512-aFHRXrNPnUhGq059XW4wWA9zdMdCPecc7RyF+MSQislXgql7LW/ek2GMbSNYt+IpuQCjP5D17r/OqCHAiUMQtA=="
         },
         "node_modules/@navikt/fnrvalidator": {
             "version": "1.1.3",
@@ -5585,14 +5585,14 @@
             }
         },
         "@navikt/aksel-icons": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@navikt/aksel-icons/-/aksel-icons-5.12.1.tgz",
-            "integrity": "sha512-4L0dARUYII+cQONZyNv5sZhZPdK0GaVtW0hw0LVQB1yzmOVQL2mGOf12jxUbMkAwKAwa1eroEAeaPVgzjpb2Ww=="
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@navikt/aksel-icons/-/aksel-icons-5.18.0.tgz",
+            "integrity": "sha512-upFPrvJLz0PbgDMqbUa/U2pj8hjUpEE+frw+3KwCvpwC8/N0yfAaK1iqBxfPw5tn8dSJ+M1UJAdDvnMnb9pNBw=="
         },
         "@navikt/ds-css": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-5.12.1.tgz",
-            "integrity": "sha512-3lkNLgDW1h4RjcDgmlqb5ELOgYPuH3HhXaQM/kAmMy0T4bsbDDANhl1o7cC+fcmDrgaayfnn05uMRXtPblQqBA=="
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-5.18.0.tgz",
+            "integrity": "sha512-69cOjIPtfgGqBPk/qmP/ifnVQk9hkvg8g4S0VRjzRQP1EgqOx775Vhoe7L22oRDbE0I8lViRHBZuspcsMBZPUg=="
         },
         "@navikt/ds-css-internal": {
             "version": "3.4.3",
@@ -5600,13 +5600,13 @@
             "integrity": "sha512-VusM4uwHZoQWiX8N/1zD6ycgNFIzYQ40TXhlP7tqpdH6sVwwzFPWCWXaZtpyjUfHxU9WyNEDYoeRAECkC0qfzg=="
         },
         "@navikt/ds-react": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-5.12.1.tgz",
-            "integrity": "sha512-6CwV66IwRuGxtJ1HAr18kTa3kVA4+T6pKHbHXRJkJZN2ELVk1306/zoOzHzyiuShvmEISoTH3X+na0DMRgNG1A==",
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-5.18.0.tgz",
+            "integrity": "sha512-jT4LiUzxRwCVUW1YIu5DKd0C8IY8k7ICwIZpjCINETJ6XIP2EtA8E8QP6wSkSbHqhtMuIuVGdRba9rWUew4Lqw==",
             "requires": {
                 "@floating-ui/react": "0.25.4",
-                "@navikt/aksel-icons": "^5.12.1",
-                "@navikt/ds-tokens": "^5.12.1",
+                "@navikt/aksel-icons": "^5.18.0",
+                "@navikt/ds-tokens": "^5.18.0",
                 "@radix-ui/react-tabs": "1.0.0",
                 "@radix-ui/react-toggle-group": "1.0.0",
                 "clsx": "^1.2.1",
@@ -5631,9 +5631,9 @@
             }
         },
         "@navikt/ds-tokens": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-tokens/-/ds-tokens-5.12.1.tgz",
-            "integrity": "sha512-oM2bXHPxhz6LW4qEFF1O+vTDBw3xZxZV2RLnMK3qQHqCWsTjb4AW4mq+4DW19KyYXV5e2vrPMqOjbv4qnNDj9A=="
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-tokens/-/ds-tokens-5.18.0.tgz",
+            "integrity": "sha512-aFHRXrNPnUhGq059XW4wWA9zdMdCPecc7RyF+MSQislXgql7LW/ek2GMbSNYt+IpuQCjP5D17r/OqCHAiUMQtA=="
         },
         "@navikt/fnrvalidator": {
             "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     },
     "dependencies": {
         "@amplitude/analytics-browser": "2.3.2",
-        "@navikt/aksel-icons": "5.12.1",
-        "@navikt/ds-css": "5.12.1",
+        "@navikt/aksel-icons": "5.18.0",
+        "@navikt/ds-css": "5.18.0",
         "@navikt/ds-css-internal": "3.4.3",
-        "@navikt/ds-react": "5.12.1",
+        "@navikt/ds-react": "5.18.0",
         "@navikt/fnrvalidator": "^1.1.3",
         "@navikt/navspa": "^5.0.1",
         "axios": "^1.6.7",


### PR DESCRIPTION
Dette gjeld følgjande avhengigheiter
- @navikt/aksel-icons
- @navikt/ds-css
- @navikt/ds-react