### PR TITLE
Fjernar ubrukte avhengigheiter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
                 "constate": "^3.3.2",
                 "dayjs": "^1.11.10",
                 "formik": "^2.4.5",
-                "nav-frontend-core": "^5.0.11",
                 "react": "18.2.0",
                 "react-dom": "18.2.0"
             },
@@ -3791,11 +3790,6 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
-        "node_modules/nav-frontend-core": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/nav-frontend-core/-/nav-frontend-core-5.1.1.tgz",
-            "integrity": "sha512-oK6VFJggnMIHsEBWXArsv+d9IO9uqUc1dp4kplHrRmTeYT2tN+pb1DA6BUOHXplGe062DIe241zYz4/lrGsmAg=="
-        },
         "node_modules/needle": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
@@ -7446,11 +7440,6 @@
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
             "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
             "dev": true
-        },
-        "nav-frontend-core": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/nav-frontend-core/-/nav-frontend-core-5.1.1.tgz",
-            "integrity": "sha512-oK6VFJggnMIHsEBWXArsv+d9IO9uqUc1dp4kplHrRmTeYT2tN+pb1DA6BUOHXplGe062DIe241zYz4/lrGsmAg=="
         },
         "needle": {
             "version": "3.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
                 "@amplitude/analytics-browser": "2.3.2",
                 "@navikt/aksel-icons": "5.18.0",
                 "@navikt/ds-css": "5.18.0",
-                "@navikt/ds-css-internal": "3.4.3",
                 "@navikt/ds-react": "5.18.0",
                 "@navikt/fnrvalidator": "^1.1.3",
                 "@navikt/navspa": "^5.0.1",
@@ -1126,11 +1125,6 @@
             "version": "5.18.0",
             "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-5.18.0.tgz",
             "integrity": "sha512-69cOjIPtfgGqBPk/qmP/ifnVQk9hkvg8g4S0VRjzRQP1EgqOx775Vhoe7L22oRDbE0I8lViRHBZuspcsMBZPUg=="
-        },
-        "node_modules/@navikt/ds-css-internal": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-css-internal/-/ds-css-internal-3.4.3.tgz",
-            "integrity": "sha512-VusM4uwHZoQWiX8N/1zD6ycgNFIzYQ40TXhlP7tqpdH6sVwwzFPWCWXaZtpyjUfHxU9WyNEDYoeRAECkC0qfzg=="
         },
         "node_modules/@navikt/ds-react": {
             "version": "5.18.0",
@@ -5593,11 +5587,6 @@
             "version": "5.18.0",
             "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-5.18.0.tgz",
             "integrity": "sha512-69cOjIPtfgGqBPk/qmP/ifnVQk9hkvg8g4S0VRjzRQP1EgqOx775Vhoe7L22oRDbE0I8lViRHBZuspcsMBZPUg=="
-        },
-        "@navikt/ds-css-internal": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-css-internal/-/ds-css-internal-3.4.3.tgz",
-            "integrity": "sha512-VusM4uwHZoQWiX8N/1zD6ycgNFIzYQ40TXhlP7tqpdH6sVwwzFPWCWXaZtpyjUfHxU9WyNEDYoeRAECkC0qfzg=="
         },
         "@navikt/ds-react": {
             "version": "5.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
                 "@navikt/aksel-icons": "5.18.0",
                 "@navikt/ds-css": "5.18.0",
                 "@navikt/ds-react": "5.18.0",
-                "@navikt/fnrvalidator": "^1.1.3",
                 "@navikt/navspa": "^5.0.1",
                 "axios": "^1.6.7",
                 "classnames": "^2.5.1",
@@ -1182,11 +1181,6 @@
             "version": "5.18.0",
             "resolved": "https://registry.npmjs.org/@navikt/ds-tokens/-/ds-tokens-5.18.0.tgz",
             "integrity": "sha512-aFHRXrNPnUhGq059XW4wWA9zdMdCPecc7RyF+MSQislXgql7LW/ek2GMbSNYt+IpuQCjP5D17r/OqCHAiUMQtA=="
-        },
-        "node_modules/@navikt/fnrvalidator": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@navikt/fnrvalidator/-/fnrvalidator-1.1.3.tgz",
-            "integrity": "sha512-xBwlPOI08kbByUWI4Yyd6NbIYLFs78I0h05mlHPjmrPPikyM89IQRbMac+6ovkgpi2s63OV6ryv3w4QqPubwiw=="
         },
         "node_modules/@navikt/navspa": {
             "version": "5.0.1",
@@ -5623,11 +5617,6 @@
             "version": "5.18.0",
             "resolved": "https://registry.npmjs.org/@navikt/ds-tokens/-/ds-tokens-5.18.0.tgz",
             "integrity": "sha512-aFHRXrNPnUhGq059XW4wWA9zdMdCPecc7RyF+MSQislXgql7LW/ek2GMbSNYt+IpuQCjP5D17r/OqCHAiUMQtA=="
-        },
-        "@navikt/fnrvalidator": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@navikt/fnrvalidator/-/fnrvalidator-1.1.3.tgz",
-            "integrity": "sha512-xBwlPOI08kbByUWI4Yyd6NbIYLFs78I0h05mlHPjmrPPikyM89IQRbMac+6ovkgpi2s63OV6ryv3w4QqPubwiw=="
         },
         "@navikt/navspa": {
             "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
         "constate": "^3.3.2",
         "dayjs": "^1.11.10",
         "formik": "^2.4.5",
-        "nav-frontend-core": "^5.0.11",
         "react": "18.2.0",
         "react-dom": "18.2.0"
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
         "@navikt/aksel-icons": "5.18.0",
         "@navikt/ds-css": "5.18.0",
         "@navikt/ds-react": "5.18.0",
-        "@navikt/fnrvalidator": "^1.1.3",
         "@navikt/navspa": "^5.0.1",
         "axios": "^1.6.7",
         "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
         "@amplitude/analytics-browser": "2.3.2",
         "@navikt/aksel-icons": "5.18.0",
         "@navikt/ds-css": "5.18.0",
-        "@navikt/ds-css-internal": "3.4.3",
         "@navikt/ds-react": "5.18.0",
         "@navikt/fnrvalidator": "^1.1.3",
         "@navikt/navspa": "^5.0.1",

--- a/src/index.less
+++ b/src/index.less
@@ -1,5 +1,4 @@
 @import '@navikt/ds-css';
-@import '@navikt/ds-css-internal';
 
 body {
     color: var(--a-text-default);


### PR DESCRIPTION
Eg har sjekka for avhengigheiter som ikkje er i bruk med `npx depcheck`. Eg har i tillegg dobbeltsjekka om dei vert referert til nokon stad. 

depcheck rapporterar feilaktig at @navikt/ds-css ikkje er i bruk. 

Det vert også meldt om at cross-env ikkje er i bruk, som stemmer, men den var del av build-stega i applikasjonen fram til oppgraderinga til Vite. Eg let den vere til vi bestemmer om den skal inn i scripta att.