### PR TITLE
Fjernar styling-fix som ikkje lengre trengs

### DIFF
--- a/src/component/components/formik/formik.less
+++ b/src/component/components/formik/formik.less
@@ -7,19 +7,9 @@
     .formik-textarea {
         margin-top: 1rem;
         max-width: 66ch;
-
-        // Midlertidig fiks som motvirkar 'position: absolute;' frå vedtaksstøttefs. 2024-01-09
-        .navds-textarea__counter {
-            position: inherit;
-        }
     }
 
     .formik-select {
         width: fit-content;
-    }
-
-    // Midlertidig fiks som motvirkar 'display: block;' frå veilarbpersonflate. 2024-01-15
-    .navds-modal:not([open]) {
-        display: none;
     }
 }


### PR DESCRIPTION
Stylinga som no er fjerna motverka styling som vart arva frå "forelder-appen" medan den brukte ein eldre utgåve av designsystemet.

Ting som tidlegare trengte fix:
- Posisjonering av "tal på teikn ein har att" i textarea
- Synlegheita av modalar når dei ikkje er opne



Reverserar endringar i følgjande PR/committar:
https://github.com/navikt/veilarbvisittkortfs/pull/393
https://github.com/navikt/veilarbvisittkortfs/pull/395/commits/289f2921f5783dae6418a0b25284b7df6fdff30e