### PR TITLE
Slettar arbeidslista når ein redigerer huskelapp

### DIFF
--- a/src/component/huskelapp/redigering/huskelapp-redigere-modal.tsx
+++ b/src/component/huskelapp/redigering/huskelapp-redigere-modal.tsx
@@ -93,6 +93,11 @@ function HuskelappRedigereModal() {
                 .then(setHuskelapp)
                 .then(showHuskelappModal)
                 .catch(showErrorModal);
+            if (!erArbeidslistaTom) {
+                slettArbeidsliste(brukerFnr)
+                    .then(res => res.data)
+                    .then(setArbeidsliste);
+            }
         } else {
             lagreHuskelapp({
                 kommentar: values.kommentar ? values.kommentar : null,


### PR DESCRIPTION
(ikkje berre når ein opprettar den fyrste gongen)

Dette er gjort mest fordi vi får artige tilfeller i dev. I realiteten (prod) vil det ikkje vere mogleg å ha både huskelapp og arbeidsliste. Ein kan ikkje opprette huskelapp utan å slette arbeidslista, og det vil ikkje vere mogleg å opprette nye arbeidslister når huskelapp og fargekategori er prodsatt. Tilstanden med både arbeidsliste og huskelapp er difor ulovleg, men vi handterar den her likevel.