### PR TITLE
Småfiks i huskelapp

### DIFF
--- a/src/component/components/formik/formik-datepicker.tsx
+++ b/src/component/components/formik/formik-datepicker.tsx
@@ -63,7 +63,7 @@ const FormikDatoVelger = ({ name, validate, label, ariaLabel, size = 'medium', c
             return (
                 <div className={datePickerClassName}>
                     <DatoVelger formikProps={formProps} ariaLabel={ariaLabel} size={size} label={label} name={name} />
-                    {error && <ErrorMessage size="medium">{error}</ErrorMessage>}
+                    {error && <ErrorMessage size={size}>{error}</ErrorMessage>}
                 </div>
             );
         }}

--- a/src/component/huskelapp/redigering/huskelapp-redigere-modal.tsx
+++ b/src/component/huskelapp/redigering/huskelapp-redigere-modal.tsx
@@ -127,6 +127,7 @@ function HuskelappRedigereModal() {
                     }}
                     open={true}
                     onClose={() => onRequestClose(formikProps)}
+                    className="rediger-huskelapp-modal"
                 >
                     <Modal.Body className="rediger-huskelapp-modal-body">
                         <HuskelappEditForm />

--- a/src/component/huskelapp/redigering/huskelapp-redigering.less
+++ b/src/component/huskelapp/redigering/huskelapp-redigering.less
@@ -1,68 +1,73 @@
 .visittkortfs {
-    .rediger-huskelapp-modal-body {
-        padding-bottom: 0;
-        overflow: visible; // Gjer at focus-stylinga ikkje vert kutta sjølv om padding-bottom er 0.
+    .rediger-huskelapp-modal {
+        max-width:  min(60rem, 100% - 2rem); // max 60rem, men unngå at modalen treff kantane av vindauget på små skjermar
 
-        display: flex;
-        flex-wrap: wrap;
-        gap: 1.5rem;
-    }
+        .rediger-huskelapp-modal-body {
+            padding-bottom: 0;
+            overflow: visible; // Gjer at focus-stylinga ikkje vert kutta sjølv om padding-bottom er 0.
 
-    .rediger-huskelapp-skjema {
-        flex-basis: 17.75rem;
-        flex-grow: 1;
-        max-width: 26rem;
-
-        display: flex;
-        flex-direction: column;
-        gap: 1.125rem;
-
-        form >:not(:last-child) {
-            margin-bottom: 1.125rem;
-        }
-    }
-
-    .arbeidsliste-innhold {
-        flex: 10 17.75rem;
-
-        background-color: var(--a-gray-100);
-        padding: 0.5rem;
-        border-radius: var(--a-border-radius-medium);
-
-        display: flex;
-        flex-direction: column;
-        align-items: start;
-        gap: 0.5rem;
-
-        h3 {
-            font-size: var(--a-font-size-medium); // 1rem, overskriv ds-styling for xsmall (1.5rem)
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1.5rem;
         }
 
-        p {
-            font-size: var(--a-font-size-small);
-            line-height: var(--a-font-line-height-medium);
+        .rediger-huskelapp-skjema {
+            flex-basis: 17.75rem;
+            flex-grow: 1;
+            max-width: 26rem;
+
+            display: flex;
+            flex-direction: column;
+            gap: 1.125rem;
+
+            form > :not(:last-child) {
+                margin-bottom: 1.125rem;
+            }
         }
 
-        .slett-arbeidsliste-container {
-            margin-bottom: 12px;
-            margin-top: 16px;
-            background: var(--a-bg-default);
-            padding: 8px 8px 12px;
+        .arbeidsliste-innhold {
+            flex: 10 18rem;
+            max-width: 60ch;
+
+            background-color: var(--a-gray-100);
+            padding: 0.5rem;
             border-radius: var(--a-border-radius-medium);
 
             display: flex;
             flex-direction: column;
-            gap: 16px;
+            align-items: start;
+            gap: 0.5rem;
 
-            .knappevalg {
+            h3 {
+                font-size: var(--a-font-size-medium); // 1rem, overskriv ds-styling for xsmall (1.5rem)
+            }
+
+            p {
+                font-size: var(--a-font-size-small);
+                line-height: var(--a-font-line-height-medium);
+                line-break: anywhere;
+            }
+
+            .slett-arbeidsliste-container {
+                margin-bottom: 12px;
+                margin-top: 16px;
+                background: var(--a-bg-default);
+                padding: 8px 8px 12px;
+                border-radius: var(--a-border-radius-medium);
+
                 display: flex;
-                gap: 0.5rem;
+                flex-direction: column;
+                gap: 16px;
+
+                .knappevalg {
+                    display: flex;
+                    gap: 0.5rem;
+                }
+            }
+
+            .sletting-av-arbeidsliste-feilet {
+                margin-bottom: 16px;
             }
         }
-
-        .sletting-av-arbeidsliste-feilet {
-            margin-bottom: 16px;
-        }
     }
-
 }

--- a/src/component/huskelapp/redigering/huskelapp-redigering.less
+++ b/src/component/huskelapp/redigering/huskelapp-redigering.less
@@ -1,6 +1,6 @@
 .visittkortfs {
     .rediger-huskelapp-modal {
-        max-width:  min(60rem, 100% - 2rem); // max 60rem, men unngå at modalen treff kantane av vindauget på små skjermar
+        max-width: min(60rem, 100% - 2rem); // max 60rem, men unngå at modalen treff kantane av vindauget på små skjermar
 
         .rediger-huskelapp-modal-body {
             padding-bottom: 0;
@@ -29,7 +29,7 @@
             flex: 10 18rem;
             max-width: 60ch;
 
-            background-color: var(--a-gray-100);
+            background-color: var(--a-grayalpha-100);
             padding: 0.5rem;
             border-radius: var(--a-border-radius-medium);
 

--- a/src/component/huskelapp/redigering/huskelapp-redigering.less
+++ b/src/component/huskelapp/redigering/huskelapp-redigering.less
@@ -45,7 +45,6 @@
             p {
                 font-size: var(--a-font-size-small);
                 line-height: var(--a-font-line-height-medium);
-                line-break: anywhere;
             }
 
             .slett-arbeidsliste-container {

--- a/src/component/huskelapp/visning/huskelapp-visning.less
+++ b/src/component/huskelapp/visning/huskelapp-visning.less
@@ -15,7 +15,7 @@
         .huskelapp-effekt-styling {
             margin-right: var(--a-spacing-8);
             background: var(--a-limegreen-100);
-            max-width: 18.75rem; // 300px
+            width: 18.75rem; // 300px
 
             position: relative;
             overflow: hidden; // skjular skuggen bak hjørnet av postitlappen
@@ -23,7 +23,6 @@
 
         // Hjørnet på "postit-lappen"
         .huskelapp-effekt-styling:before {
-            max-width: 18.75rem; // 300px
             content: '';
             position: absolute;
             top: 0;

--- a/src/mock/api/veilarbportefolje.ts
+++ b/src/mock/api/veilarbportefolje.ts
@@ -74,7 +74,7 @@ export const veilarbportefoljeHandlers: RequestHandler[] = [
     }),
     http.delete('/veilarbportefolje/api/v2/arbeidsliste', async () => {
         await delay(defaultNetworkResponseDelay);
-        return HttpResponse.json(mockArbeidsliste);
+        return HttpResponse.json(mockTomArbeidsliste);
     }),
     http.post('/veilarbportefolje/api/v1/hent-huskelapp-for-bruker', async () => {
         await delay(defaultNetworkResponseDelay);


### PR DESCRIPTION
Trellokort: https://trello.com/c/VqQ1JX4T/566-sm%C3%A5-og-litt-st%C3%B8rre-fiks-i-rediger-huskelapp-modalar


Denne PR-en har stort sett endringar i styling, derunder tema som "kor mykje tekst skal vi sjå", "kor breie skal ting vere" og "la oss bruke same font-storleik for alle feilmeldingane i dette skjemaet".

Den legg også opp til at koden skal kunne gjenbrukast i Oversikten, ved at bakgrunnsfargen på arbeidslista no er gjennomsiktig (og difor vil visast som ein grå boks også når forelderen har bakgrunnsfarge).