### PR TITLE
Ny aldersfunksjon som tar høyde for skuddår

### DIFF
--- a/src/component/personinfo/components/navnogalder.tsx
+++ b/src/component/personinfo/components/navnogalder.tsx
@@ -3,8 +3,13 @@ import { OrNothing } from '../../../util/type/utility-types';
 import { Heading } from '@navikt/ds-react';
 
 export function kalkulerAlder(fodselsdato: Date): number {
-    const diff = Date.now() - fodselsdato.getTime();
-    return new Date(diff).getUTCFullYear() - 1970;
+    const iDag = new Date();
+    const alder = iDag.getFullYear() - fodselsdato.getFullYear();
+    const maned = iDag.getMonth() - fodselsdato.getMonth();
+    if (maned < 0 || (maned === 0 && iDag.getDate() < fodselsdato.getDate())) {
+        return alder - 1;
+    }
+    return alder;
 }
 
 export function lagAlderTekst(personalia: OrNothing<Personalia>): string {
@@ -12,7 +17,7 @@ export function lagAlderTekst(personalia: OrNothing<Personalia>): string {
         return '';
     }
     const alder = kalkulerAlder(new Date(personalia.fodselsdato));
-    return `(${alder} år)`;
+    return `(${alder} år)`;
 }
 
 function NavnOgAlder(props: { personalia: OrNothing<Personalia>; navn: string }) {

--- a/src/mock/api/veilarbperson.ts
+++ b/src/mock/api/veilarbperson.ts
@@ -8,8 +8,8 @@ import {
     SpraakTolk,
     VergeOgFullmakt
 } from '../../api/veilarbperson';
-import {defaultNetworkResponseDelay} from '../config';
-import {delay, http, HttpResponse, RequestHandler} from 'msw';
+import { defaultNetworkResponseDelay } from '../config';
+import { delay, http, HttpResponse, RequestHandler } from 'msw';
 
 const mockHarBruktNivaa4: HarBruktNivaa4Type = {
     harbruktnivaa4: false


### PR DESCRIPTION
[TC-584](https://trello.com/c/bPNUHlnk)
[FAGSYSTEM-322873](https://jira.adeo.no/browse/FAGSYSTEM-322873) og [FAGSYSTEM-322608](https://jira.adeo.no/browse/FAGSYSTEM-322608) oppdaget en bug i visittkortet (og detaljer). Aldersutregningsfunksjonen vår er litt for simpel og ender opp med å regne én dag feil i skuddår, fra 1. mars til 31. desember. Alle som fyller år i det tidsrommet får sin nye alder en dag for tidlig. Gjelder ikke oversikten, der gjøres utregningen i backenden.