### PR TITLE
Ikke slette fargekategori ved migrering av arbeidsliste til huskelapp

### DIFF
--- a/src/api/veilarbportefolje.ts
+++ b/src/api/veilarbportefolje.ts
@@ -94,6 +94,12 @@ export function slettArbeidsliste(fnr: string): AxiosPromise<Arbeidsliste> {
     return axiosInstance.delete(`/veilarbportefolje/api/v2/arbeidsliste`, { data: { fnr: fnr } });
 }
 
+export function slettArbeidslisteUtenFargekategori(fnr: string): AxiosPromise<Arbeidsliste> {
+    return axiosInstance.delete(`/veilarbportefolje/api/v2/arbeidsliste?slettFargekategori=false`, {
+        data: { fnr: fnr }
+    });
+}
+
 export function fetchHuskelapp(fnr: string, enhetId: string): AxiosPromise<Huskelapp> {
     return axiosInstance.post(`/veilarbportefolje/api/v1/hent-huskelapp-for-bruker`, { fnr: fnr, enhetId: enhetId });
 }

--- a/src/component/arbeidsliste/arbeidsliste.less
+++ b/src/component/arbeidsliste/arbeidsliste.less
@@ -99,11 +99,12 @@
     justify-self: left;
     margin-top: 0.5rem;
     margin-bottom: 0.2rem;
+    display: flex;
 
     label {
         position: relative;
         cursor: pointer;
-        padding: 0.6rem 0.5rem 0;
+        padding: 0.6rem 0.5rem 0.6rem;
         border: 1px solid transparent;
     }
 

--- a/src/component/huskelapp/redigering/huskelapp-redigere-modal.tsx
+++ b/src/component/huskelapp/redigering/huskelapp-redigere-modal.tsx
@@ -6,7 +6,8 @@ import {
     HuskelappformValues,
     lagreHuskelapp,
     redigerHuskelapp,
-    slettArbeidsliste
+    slettArbeidsliste,
+    slettArbeidslisteUtenFargekategori
 } from '../../../api/veilarbportefolje';
 import { useAppStore } from '../../../store/app-store';
 import { useDataStore } from '../../../store/data-store';
@@ -100,7 +101,7 @@ function HuskelappRedigereModal() {
                 .then(showHuskelappModal)
                 .catch(showErrorModal);
             if (!erArbeidslistaTom) {
-                slettArbeidsliste(brukerFnr)
+                slettArbeidslisteUtenFargekategori(brukerFnr)
                     .then(res => res.data)
                     .then(setArbeidsliste);
             }
@@ -116,7 +117,7 @@ function HuskelappRedigereModal() {
                 .then(setHuskelapp)
                 .then(showHuskelappModal)
                 .catch(showErrorModal);
-            slettArbeidsliste(brukerFnr)
+            slettArbeidslisteUtenFargekategori(brukerFnr)
                 .then(res => res.data)
                 .then(setArbeidsliste);
         }

--- a/src/component/huskelapp/redigering/huskelapp-slett-arbeidsliste.tsx
+++ b/src/component/huskelapp/redigering/huskelapp-slett-arbeidsliste.tsx
@@ -5,7 +5,7 @@ import { useAppStore } from '../../../store/app-store';
 import { useDataStore } from '../../../store/data-store';
 import { logMetrikk } from '../../../util/logger';
 import { trackAmplitude } from '../../../amplitude/amplitude';
-import { slettArbeidsliste } from '../../../api/veilarbportefolje';
+import { slettArbeidslisteUtenFargekategori } from '../../../api/veilarbportefolje';
 import { ifResponseHasData } from '../../../util/utils';
 
 export const SlettArbeidsliste = () => {
@@ -24,7 +24,7 @@ export const SlettArbeidsliste = () => {
         });
         setLoading(true);
 
-        slettArbeidsliste(brukerFnr)
+        slettArbeidslisteUtenFargekategori(brukerFnr)
             .then(ifResponseHasData(setArbeidsliste))
             .then(() => setLoading(false))
             .catch(() => setError(true))

--- a/src/mock/api/veilarbpersonflatefs.ts
+++ b/src/mock/api/veilarbpersonflatefs.ts
@@ -4,7 +4,7 @@ import { delay, http, HttpResponse, RequestHandler } from 'msw';
 
 const mockFeatures: OboUnleashFeatures = {
     [BRUK_GAMMEL_ARBEIDSREGISTRERING_URL]: true,
-    [HUSKELAPP]: true
+    [HUSKELAPP]: false
 };
 
 export const veilarbpersonflatefsHandlers: RequestHandler[] = [

--- a/src/mock/api/veilarbportefolje.ts
+++ b/src/mock/api/veilarbportefolje.ts
@@ -27,6 +27,18 @@ const mockTomArbeidsliste: Arbeidsliste = {
     kategori: null
 };
 
+const mockTomArbeidslisteMedFargekategori: Arbeidsliste = {
+    arbeidslisteAktiv: null,
+    endringstidspunkt: null,
+    frist: null,
+    harVeilederTilgang: false,
+    isOppfolgendeVeileder: false,
+    kommentar: null,
+    overskrift: null,
+    sistEndretAv: null,
+    kategori: KategoriModell.GUL
+};
+
 const mockHuskelapp: Huskelapp = {
     huskelappId: 'e4c54511-7668-4b89-9436-9acfd85071ff',
     kommentar:
@@ -73,8 +85,14 @@ export const veilarbportefoljeHandlers: RequestHandler[] = [
             kategori: requestBody.kategori
         });
     }),
-    http.delete('/veilarbportefolje/api/v2/arbeidsliste', async () => {
+    http.delete('/veilarbportefolje/api/v2/arbeidsliste', async ({ request }) => {
+        const url = new URL(request.url);
+        const slettFargekategori = url.searchParams.get('slettFargekategori');
         await delay(defaultNetworkResponseDelay);
+
+        if (slettFargekategori === 'false') {
+            return HttpResponse.json(mockTomArbeidslisteMedFargekategori);
+        }
         return HttpResponse.json(mockTomArbeidsliste);
     }),
     http.post('/veilarbportefolje/api/v1/hent-huskelapp-for-bruker', async () => {


### PR DESCRIPTION
Må ha to forskjellige kall mot endepunkt "slett arbeidsliste" så lenge vi fortsatt støtter arbeidslistefunksjon i visittkortet.

1. Slett arbeidsliste med tilhørende fargekategori (slett fra arbeidsliste modal)
2. Slett arbeidsliste uten å slette fargekategori (slett fra migreringsmodal: arbeidsliste til huskelapp)