### PR TITLE
Hent dialoger og gjeldende-varsel uten fnr i query

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -10,7 +10,9 @@ export function isAnyLoading(...fetchers: Array<{ loading: boolean }>): boolean 
     return fetchers.some(f => f.loading);
 }
 
-export function isAnyLoadingOrNotStarted(...fetchers: Array<{ data?: any; error?: any; loading: boolean }>): boolean {
+export function isAnyLoadingOrNotStarted(
+    ...fetchers: Array<{ data?: object; error?: object; loading: boolean }>
+): boolean {
     return fetchers.some(f => f.loading || (!f.error && !f.data));
 }
 
@@ -18,6 +20,6 @@ export function hasAnyFailed(...fetchers: Array<{ error?: AxiosError }>): boolea
     return fetchers.some(f => f.error);
 }
 
-export function hasAllData(...fetchers: Array<{ data?: any }>): boolean {
+export function hasAllData(...fetchers: Array<{ data?: object }>): boolean {
     return fetchers.every(f => isDefined(f.data));
 }

--- a/src/api/veilarbdialogGraphql.ts
+++ b/src/api/veilarbdialogGraphql.ts
@@ -1,0 +1,44 @@
+import { Dialog, GjeldendeEskaleringsvarsel } from './veilarbdialog';
+
+export const stansVarselQuery = `
+    query($fnr: String!) {
+        stansVarsel(fnr: $fnr) {
+            id,
+            tilhorendeDialogId,
+            opprettetAv,
+            opprettetDato,
+            opprettetBegrunnelse
+        }
+    }
+`;
+
+export const dialogerQuery = `
+    query($fnr: String!) {
+        dialoger(fnr: $fnr) {
+            ferdigBehandlet,
+            historisk,
+            id,
+            venterPaSvar
+        }
+    }
+`;
+
+interface GraphqlError {
+    message: string;
+}
+
+interface GraphqlResponse<T> {
+    data: T;
+    errors: GraphqlError[];
+}
+export type DialogerResponse = GraphqlResponse<{ dialoger: Dialog[] }>;
+export type StansVarselResponse = GraphqlResponse<{ stansVarsel: GjeldendeEskaleringsvarsel }>;
+
+export const veilarbdialogGraphqlQuery = (fnr: string, query: string) => {
+    return {
+        query,
+        variables: {
+            fnr
+        }
+    };
+};

--- a/src/mock/api/veilarbdialog.ts
+++ b/src/mock/api/veilarbdialog.ts
@@ -1,66 +1,27 @@
-import { Egenskaper, EskaleringsvarselHistorikkInnslag, GjeldendeEskaleringsvarsel } from '../../api/veilarbdialog';
+import {
+    EskaleringsvarselHistorikkInnslag,
+    GjeldendeEskaleringsvarsel,
+    veilarbDialogGraphqlEndpoint
+} from '../../api/veilarbdialog';
 import { defaultNetworkResponseDelay } from '../config';
 import { delay, http, HttpResponse, RequestHandler } from 'msw';
 
-const mockHenvendelseData: any = {
-    aktivitetId: null,
-    egenskaper: [Egenskaper.ESKALERINGSVARSEL],
-    erLestAvBruker: false,
-    ferdigBehandlet: true,
-    henvendelser: [
-        {
-            avsender: 'VEILEDER',
-            avsenderId: 'Z123456',
-            dialogId: '1665',
-            id: '2201',
-            lest: true,
-            sendt: '2019-04-04T13:34:51.086+02:00',
-            tekst:
-                'Generell innledningstekst:Les denne meldingen nøye og gi beskjed til veilederen din hvis det er noe du lurer på. Det gjør du ved å svare på denne meldingen.'
-        }
-    ],
-    historisk: false,
-    id: '1665',
-    lest: true,
-    lestAvBrukerTidspunkt: null,
-    opprettetDato: '2019-04-04T13:34:51.057+02:00',
-    overskrift: 'Du har fått et varsel fra NAV',
-    sisteDato: '2019-04-04T13:34:51.086+02:00',
-    sisteTekst:
-        'Generell innledningstekst:Les denne meldingen nøye og gi beskjed til veilederen din hvis det er noe du lurer på. Det gjør du ved å svare på denne meldingen.',
-    venterPaSvar: false
-};
-
 export const veilarbdialogHandlers: RequestHandler[] = [
-    http.get('/veilarbdialog/api/dialog', async () => {
+    http.post(veilarbDialogGraphqlEndpoint, async ({ request }) => {
+        const body = (await request.json()) as { query: string };
         await delay(defaultNetworkResponseDelay);
-        return HttpResponse.json([]);
-    }),
-    http.post('/veilarbdialog/api/dialog', async () => {
-        await delay(defaultNetworkResponseDelay);
-        return HttpResponse.json(mockHenvendelseData);
-    }),
-    http.put('/veilarbdialog/api/dialog/:dialogId/ferdigbehandlet/true', async () => {
-        await delay(defaultNetworkResponseDelay);
-        return HttpResponse.json(mockHenvendelseData);
-    }),
-    http.put('/veilarbdialog/api/dialog/:dialogId/venter_pa_svar/true', async () => {
-        await delay(defaultNetworkResponseDelay);
-
-        return HttpResponse.json(mockHenvendelseData);
-    }),
-
-    http.get('/veilarbdialog/api/eskaleringsvarsel/gjeldende', async () => {
-        const gjeldendeEskaleringsvarsel: GjeldendeEskaleringsvarsel = {
-            id: 1,
-            tilhorendeDialogId: 42,
-            opprettetAv: 'Z123456',
-            opprettetDato: new Date().toISOString(),
-            opprettetBegrunnelse: 'begrunnelse'
-        };
-
-        await delay(defaultNetworkResponseDelay);
-        return HttpResponse.json(gjeldendeEskaleringsvarsel);
+        if (body.query.includes('stansVarsel')) {
+            const gjeldendeEskaleringsvarsel: GjeldendeEskaleringsvarsel = {
+                id: 1,
+                tilhorendeDialogId: 42,
+                opprettetAv: 'Z123456',
+                opprettetDato: new Date().toISOString(),
+                opprettetBegrunnelse: 'begrunnelse'
+            };
+            return HttpResponse.json({ data: { stansVarsel: gjeldendeEskaleringsvarsel } });
+        } else {
+            return HttpResponse.json({ data: { dialoger: [] } });
+        }
     }),
     http.get('/veilarbdialog/api/eskaleringsvarsel/historikk', async () => {
         const now = new Date();


### PR DESCRIPTION
- Hent dialoger og gjeldende stansVarsel (eskaleringsvarsel) via graphql-api-et til veilarbdialog istedetfor endepunkter som bruker fnr i query
- Div opprydding av mocking som ikke er i bruk