### PR TITLE
Ikke kalle portefolje kall dersom man ikke er i personflate

### DIFF
--- a/src/api/veilarbportefolje.ts
+++ b/src/api/veilarbportefolje.ts
@@ -127,40 +127,40 @@ export function endreFargekategori(fargekategoriVerdi: string, fnr: string): Axi
     return axiosInstance.put('/veilarbportefolje/api/v1/fargekategorier', { fargekategoriVerdi, fnr: [fnr] });
 }
 
-export function useErUfordeltBruker(fnr: string) {
+export function useErUfordeltBruker(fnr: string, skalHenteData: boolean = true) {
     const url = '/veilarbportefolje/api/v1/hent-er-bruker-ufordelt';
     const { data, error, isLoading, mutate } = useSWR<boolean, ErrorMessage>(
-        fnr ? `${url}/${fnr}` : null,
+        skalHenteData && fnr ? `${url}/${fnr}` : null,
         () => fetchWithPost(url, { fnr: fnr ?? null }),
         swrOptions
     );
     return { data, isLoading, error, mutate };
 }
 
-export function useHuskelapp(fnr: string) {
+export function useHuskelapp(fnr: string, skalHenteData: boolean = true) {
     const url = '/veilarbportefolje/api/v1/hent-huskelapp-for-bruker';
     const { data, error, isLoading, mutate } = useSWR<Huskelapp, ErrorMessage>(
-        fnr ? `${url}/${fnr}` : null,
+        skalHenteData && fnr ? `${url}/${fnr}` : null,
         () => fetchWithPost(url, { fnr: fnr }),
         swrOptions
     );
     return { data, isLoading, error, mutate };
 }
 
-export function useArbeidsliste(fnr: string) {
+export function useArbeidsliste(fnr: string, skalHenteData: boolean = true) {
     const url = '/veilarbportefolje/api/v2/hent-arbeidsliste';
     const { data, error, isLoading, mutate } = useSWR<Arbeidsliste, ErrorMessage>(
-        fnr ? `${url}/${fnr}` : null,
+        skalHenteData && fnr ? `${url}/${fnr}` : null,
         () => fetchWithPost(url, { fnr: fnr }),
         swrOptions
     );
     return { data, isLoading, error, mutate };
 }
 
-export function useFargekategori(fnr: string) {
+export function useFargekategori(fnr: string, skalHenteData: boolean = true) {
     const url = '/veilarbportefolje/api/v1/hent-fargekategori';
     const { data, error, isLoading, mutate } = useSWR<Fargekategori, ErrorMessage>(
-        fnr ? `${url}/${fnr}` : null,
+        skalHenteData && fnr ? `${url}/${fnr}` : null,
         () => fetchWithPost(url, { fnr: fnr }),
         swrOptions
     );

--- a/src/component/arbeidsliste/arbeidsliste-knapp.tsx
+++ b/src/component/arbeidsliste/arbeidsliste-knapp.tsx
@@ -11,8 +11,8 @@ export interface ArbeidslisteKnappProps {
 }
 
 function ArbeidslisteKnapp(props: ArbeidslisteKnappProps) {
-    const { brukerFnr } = useAppStore();
-    const { data: arbeidsliste } = useArbeidsliste(brukerFnr);
+    const { brukerFnr, visVeilederVerktoy } = useAppStore();
+    const { data: arbeidsliste } = useArbeidsliste(brukerFnr, visVeilederVerktoy);
 
     if (props.hidden) {
         return null;

--- a/src/component/arbeidsliste/arbeidsliste-modal.tsx
+++ b/src/component/arbeidsliste/arbeidsliste-modal.tsx
@@ -29,10 +29,10 @@ const arbeidslisteEmptyValues = {
 };
 
 function ArbeidslisteModal() {
-    const { brukerFnr } = useAppStore();
+    const { brukerFnr, visVeilederVerktoy } = useAppStore();
     const { hideModal, showSpinnerModal, showErrorModal, showFjernArbeidslisteModal } = useModalStore();
     const { oppfolging, innloggetVeileder, personalia } = useDataStore();
-    const { data: arbeidsliste, mutate: setArbeidsliste } = useArbeidsliste(brukerFnr);
+    const { data: arbeidsliste, mutate: setArbeidsliste } = useArbeidsliste(brukerFnr, visVeilederVerktoy);
 
     const liste = arbeidsliste as Arbeidsliste;
 

--- a/src/component/arbeidsliste/fjern-arbeidsliste-modal.tsx
+++ b/src/component/arbeidsliste/fjern-arbeidsliste-modal.tsx
@@ -10,9 +10,9 @@ import { trackAmplitude } from '../../amplitude/amplitude';
 import { BodyShort, Heading, Button } from '@navikt/ds-react';
 
 function FjernArbeidslisteModal() {
-    const { brukerFnr } = useAppStore();
+    const { brukerFnr, visVeilederVerktoy } = useAppStore();
     const { personalia } = useDataStore();
-    const { mutate: setArbeidsliste } = useArbeidsliste(brukerFnr);
+    const { mutate: setArbeidsliste } = useArbeidsliste(brukerFnr, visVeilederVerktoy);
 
     const { showSpinnerModal, showErrorModal, hideModal } = useModalStore();
 

--- a/src/component/fargekategori/fargekategoriknapp.tsx
+++ b/src/component/fargekategori/fargekategoriknapp.tsx
@@ -11,8 +11,8 @@ interface Props {
 
 export const Fargekategoriknapp = ({ isLoading }: Props) => {
     const buttonRef = useRef<HTMLButtonElement>(null);
-    const { brukerFnr } = useAppStore();
-    const { data: fargekategori, mutate: setFargekategori } = useFargekategori(brukerFnr);
+    const { brukerFnr, visVeilederVerktoy } = useAppStore();
+    const { data: fargekategori, mutate: setFargekategori } = useFargekategori(brukerFnr, visVeilederVerktoy);
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
     const titletekst = fargekategori?.fargekategoriVerdi
         ? 'Kategori ' + Fargekategorinavn[fargekategori.fargekategoriVerdi].toLowerCase()

--- a/src/component/huskelapp/redigering/huskelapp-redigere-modal.tsx
+++ b/src/component/huskelapp/redigering/huskelapp-redigere-modal.tsx
@@ -32,11 +32,11 @@ const huskelappEmptyValues = {
 };
 
 function HuskelappRedigereModal() {
-    const { brukerFnr, enhetId } = useAppStore();
+    const { brukerFnr, visVeilederVerktoy, enhetId } = useAppStore();
     const { innloggetVeileder } = useDataStore();
     const { hideModal, showSpinnerModal, showErrorModal } = useModalStore();
-    const { data: arbeidsliste, mutate: setArbeidsliste } = useArbeidsliste(brukerFnr);
-    const { data: huskelapp, mutate: setHuskelapp } = useHuskelapp(brukerFnr);
+    const { data: arbeidsliste, mutate: setArbeidsliste } = useArbeidsliste(brukerFnr, visVeilederVerktoy);
+    const { data: huskelapp, mutate: setHuskelapp } = useHuskelapp(brukerFnr, visVeilederVerktoy);
 
     const erArbeidslistaTom =
         arbeidsliste?.sistEndretAv == null ||

--- a/src/component/huskelapp/redigering/slett-huskelapp.tsx
+++ b/src/component/huskelapp/redigering/slett-huskelapp.tsx
@@ -11,10 +11,10 @@ interface Props {
 }
 
 export const SlettHuskelapp = ({ variant = 'secondary' }: Props) => {
-    const { brukerFnr } = useAppStore();
+    const { brukerFnr, visVeilederVerktoy } = useAppStore();
     const { showFjernHuskelappModal } = useModalStore();
     const { innloggetVeileder, oppfolging } = useDataStore();
-    const { data: huskelapp } = useHuskelapp(brukerFnr);
+    const { data: huskelapp } = useHuskelapp(brukerFnr, visVeilederVerktoy);
 
     if (!huskelapp || !innloggetVeileder) {
         // Vi manglar data for å bestemme om slettknappen kan visast

--- a/src/component/huskelapp/visning/huskelapp-fjern-modal.tsx
+++ b/src/component/huskelapp/visning/huskelapp-fjern-modal.tsx
@@ -6,8 +6,8 @@ import { Button, Heading, Modal } from '@navikt/ds-react';
 import { useAppStore } from '../../../store/app-store';
 
 function HuskelappFjernModal() {
-    const { brukerFnr } = useAppStore();
-    const { data: huskelapp, mutate: setHuskelapp } = useHuskelapp(brukerFnr);
+    const { brukerFnr, visVeilederVerktoy } = useAppStore();
+    const { data: huskelapp, mutate: setHuskelapp } = useHuskelapp(brukerFnr, visVeilederVerktoy);
     const { showSpinnerModal, showErrorModal, hideModal } = useModalStore();
 
     function handleSlettHuskelapp() {

--- a/src/component/personinfo/personinfo.tsx
+++ b/src/component/personinfo/personinfo.tsx
@@ -24,8 +24,8 @@ import { useArbeidsliste, useErUfordeltBruker, useHuskelapp } from '../../api/ve
 import { useOppfolgingsstatus, useTilgangTilBrukersKontor } from '../../api/veilarboppfolging';
 
 function PersonInfo() {
-    const { brukerFnr } = useAppStore();
-    const { personalia, features } = useDataStore();
+    const { brukerFnr, visVeilederVerktoy } = useAppStore();
+    const { personalia, features, oppfolging } = useDataStore();
     const { showArbeidslisteModal, showHuskelappRedigereModal } = useModalStore();
     const {
         data: oppfolgingsstatus,
@@ -36,13 +36,17 @@ function PersonInfo() {
         data: arbeidsliste,
         isLoading: arbeidslisteIsLoading,
         error: arbeidslisteError
-    } = useArbeidsliste(brukerFnr);
-    const { data: huskelapp, isLoading: huskelappIsLoading, error: huskelappError } = useHuskelapp(brukerFnr);
+    } = useArbeidsliste(brukerFnr, visVeilederVerktoy);
+    const {
+        data: huskelapp,
+        isLoading: huskelappIsLoading,
+        error: huskelappError
+    } = useHuskelapp(brukerFnr, visVeilederVerktoy);
     const {
         data: erUfordeltBruker,
         isLoading: erUfordeltBrukerIsLoading,
         error: erUfordeltBrukerError
-    } = useErUfordeltBruker(brukerFnr);
+    } = useErUfordeltBruker(brukerFnr, visVeilederVerktoy && oppfolging?.underOppfolging);
     const {
         data: tilgangTilBrukersKontor,
         isLoading: tilgangTilBrukersKontorIsLoading,

--- a/src/component/veilederverktoy/tildel-veileder/tildel-veileder-kvittering.tsx
+++ b/src/component/veilederverktoy/tildel-veileder/tildel-veileder-kvittering.tsx
@@ -9,9 +9,9 @@ export interface TildelVeilederKvitteringProps {
 }
 
 export function TildelVeilederKvittering(props: TildelVeilederKvitteringProps) {
-    const { brukerFnr } = useAppStore();
+    const { brukerFnr, visVeilederVerktoy } = useAppStore();
     const { hideModal } = useModalStore();
-    const { mutate: setUfordeltbruker } = useErUfordeltBruker(brukerFnr);
+    const { mutate: setUfordeltbruker } = useErUfordeltBruker(brukerFnr, visVeilederVerktoy);
 
     return (
         <VarselModal isOpen={true} onRequestClose={hideModal} type="SUCCESS" inkluderIkon={false}>

--- a/src/component/veilederverktoy/tildel-veileder/tildel-veileder.tsx
+++ b/src/component/veilederverktoy/tildel-veileder/tildel-veileder.tsx
@@ -13,10 +13,10 @@ import { BodyShort, Button, Heading, Modal } from '@navikt/ds-react';
 import { useArbeidsliste, useFargekategori, useHuskelapp } from '../../../api/veilarbportefolje';
 
 function TildelVeileder() {
-    const { brukerFnr } = useAppStore();
-    const { data: arbeidsliste } = useArbeidsliste(brukerFnr);
-    const { data: huskelapp } = useHuskelapp(brukerFnr);
-    const { data: fargekategori } = useFargekategori(brukerFnr);
+    const { brukerFnr, visVeilederVerktoy } = useAppStore();
+    const { data: arbeidsliste } = useArbeidsliste(brukerFnr, visVeilederVerktoy);
+    const { data: huskelapp } = useHuskelapp(brukerFnr, visVeilederVerktoy);
+    const { data: fargekategori } = useFargekategori(brukerFnr, visVeilederVerktoy);
     const { showTildelVeilederKvitteringModal, showTildelVeilederFeiletModal, hideModal } = useModalStore();
     const [visAdvarselOmSletting, setVisAdvarselOmSletting] = useState<boolean>(false);
     const { data: oppfolgingstatus, mutate: setOppfolgingsstatus } = useOppfolgingsstatus(brukerFnr);

--- a/src/component/veilederverktoy/veilederverktoylinje.tsx
+++ b/src/component/veilederverktoy/veilederverktoylinje.tsx
@@ -34,13 +34,16 @@ import { useOppfolgingsstatus, useTilgangTilBrukersKontor } from '../../api/veil
 
 function Veilederverktoylinje() {
     const { visVeilederVerktoy, brukerFnr } = useAppStore();
+    const { oppfolging, innloggetVeileder, gjeldendeEskaleringsvarsel, features } = useDataStore();
     const { data: oppfolgingsstatus, error: oppfolgingsstatusError } = useOppfolgingsstatus(brukerFnr);
-    const { data: arbeidsliste, error: arbeidslisteError } = useArbeidsliste(brukerFnr);
-    const { data: huskelapp, error: huskelappError } = useHuskelapp(brukerFnr);
-    const { data: erUfordeltBruker, error: erUfordeltBrukerError } = useErUfordeltBruker(brukerFnr);
+    const { data: arbeidsliste, error: arbeidslisteError } = useArbeidsliste(brukerFnr, visVeilederVerktoy);
+    const { data: huskelapp, error: huskelappError } = useHuskelapp(brukerFnr, visVeilederVerktoy);
+    const { data: erUfordeltBruker, error: erUfordeltBrukerError } = useErUfordeltBruker(
+        brukerFnr,
+        visVeilederVerktoy && oppfolging?.underOppfolging
+    );
     const { data: tilgangTilBrukersKontor, error: tilgangTilBrukersKontorError } =
         useTilgangTilBrukersKontor(brukerFnr);
-    const { oppfolging, innloggetVeileder, gjeldendeEskaleringsvarsel, features } = useDataStore();
     const {
         showArbeidslisteModal,
         showTildelVeilederModal,


### PR DESCRIPTION
Dette hjelper både arbeidssøkerregisteret sine interne flater fra å få masse 404, dette trengs nok ikke å vises i deres flater