### PR TITLE
Justerer styling for personinfo i huskelappredigering

### DIFF
--- a/src/component/huskelapp/redigering/huskelapp-redigere-modal.tsx
+++ b/src/component/huskelapp/redigering/huskelapp-redigere-modal.tsx
@@ -1,5 +1,5 @@
 import { Formik, FormikBag, FormikProps } from 'formik';
-import { Button, Heading, Modal } from '@navikt/ds-react';
+import { BodyShort, Button, CopyButton, Heading, Modal } from '@navikt/ds-react';
 import { ArrowRightIcon } from '@navikt/aksel-icons';
 import {
     Huskelapp,
@@ -22,7 +22,6 @@ import { SlettArbeidsliste } from './huskelapp-slett-arbeidsliste';
 import { SlettHuskelapp } from './slett-huskelapp';
 import './huskelapp-redigering.less';
 import { useDataStore } from '../../../store/data-store';
-import { KopierKnappTekst } from '../../components/kopier-knapp/kopier-knapp';
 import { selectSammensattNavn } from '../../../util/selectors';
 
 const huskelappEmptyValues = {
@@ -166,15 +165,22 @@ function HuskelappRedigereModal() {
                     <Modal.Header>
                         <div className="rediger-huskelapp-modal-header">
                             <HuskelappIkon aria-hidden className="navds-modal__header-icon" />
-                            <Heading size="xsmall" className="rediger-huskelapp-modal-header-tekst">
+                            <Heading size="small" className="rediger-huskelapp-modal-header-tekst">
                                 {modalNavn}
                             </Heading>
                         </div>
-                        <div className="rediger-huskelapp-modal-header">
-                            <Heading size="xsmall" level="3">
+                        <div className="rediger-huskelapp-modal-personinfo">
+                            <BodyShort weight="semibold" size="small">
                                 {navn}
-                            </Heading>
-                            <KopierKnappTekst kopierTekst={brukerFnr} viseTekst={`F.nr.: ${brukerFnr}`} />
+                            </BodyShort>
+                            <CopyButton
+                                copyText={brukerFnr}
+                                text={`F.nr.: ${brukerFnr}`}
+                                activeText="Kopiert!"
+                                size="xsmall"
+                                iconPosition="right"
+                                className="copybutton"
+                            />
                         </div>
                     </Modal.Header>
                     <Modal.Body className="rediger-huskelapp-modal-body">

--- a/src/component/huskelapp/redigering/huskelapp-redigering.less
+++ b/src/component/huskelapp/redigering/huskelapp-redigering.less
@@ -17,6 +17,24 @@
         .rediger-huskelapp-modal-header-tekst {
             margin-left: 0.3rem;
         }
+
+        .rediger-huskelapp-modal-personinfo {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            column-gap: 0.5rem;
+            row-gap: 0.1rem;
+
+            /* I oversikten er (nesten) all tekst 0.875rem, så vi etterliknar det på personinfoen her også.
+             * Ikonet får likevel vere stort (tilsvarar 20px) */
+            p, button span {
+                font-size: var(--a-font-size-small);
+            }
+            svg {
+                font-size: var(--a-font-size-xlarge);
+            }
+        }
+
         .rediger-huskelapp-modal-body {
             padding-bottom: 0;
             overflow: visible; // Gjer at focus-stylinga ikkje vert kutta sjølv om padding-bottom er 0.


### PR DESCRIPTION
- Let vere å gjenbruke kopierknapp som er spesialtilpassa til visittkort-rada. Mellom anna fordi den kjem med ein fast storleik.
- Byttar headingstorleik på modalen så den vert lik som i oversikta
- Brukar mindre knapp og tekst slik at personinformasjonen vert mindre dominerande.
- Etterlikner tekststorleik frå oversikten på knapp og avsnittstekst.

Før endring:

<img width="300" alt="Screenshot 2024-07-16 at 13 06 15" src="https://github.com/user-attachments/assets/2907f1c6-6378-4efe-8345-b94ba7f8047f">

Etter endring:

<img width="300" alt="Screenshot 2024-07-16 at 13 04 47" src="https://github.com/user-attachments/assets/4d1bded6-fde1-478e-b003-2720d6b32da8">

Etter endring, person med langt namn:

<img width="300" alt="Screenshot 2024-07-16 at 13 05 31" src="https://github.com/user-attachments/assets/5a13944d-0724-4555-87c2-aa5ae8c81e84">