### PR TITLE
Rydd i koden til veilederverktøykomponent

### DIFF
--- a/src/component/veilederverktoy/prosess/start-prosess.tsx
+++ b/src/component/veilederverktoy/prosess/start-prosess.tsx
@@ -15,9 +15,11 @@ function StartProcess(props: StartProsessProps & ClickMetricProps) {
         setAvsluttOppfolgingOpptelt(false);
     }
     return (
-        <ProcessKnapp onClick={props.onClick} metricName={props.metricName}>
-            {props.knappeTekst}
-        </ProcessKnapp>
+        <li>
+            <ProcessKnapp onClick={props.onClick} metricName={props.metricName}>
+                {props.knappeTekst}
+            </ProcessKnapp>
+        </li>
     );
 }
 

--- a/src/component/veilederverktoy/start-registrering/start-registrering-prosess.tsx
+++ b/src/component/veilederverktoy/start-registrering/start-registrering-prosess.tsx
@@ -28,14 +28,19 @@ function StartRegistreringProsess() {
     if (!kanRegistreres) {
         return null;
     }
-    const brukerType = oppfolging?.erSykmeldtMedArbeidsgiver
-        ? 'erSykemeldtMedArbeidsgiver'
-        : oppfolging?.kanReaktiveres
-          ? 'kanReaktiveres'
-          : 'kanIkkeReaktiveres';
+
+    const brukerType = () => {
+        if (oppfolging?.erSykmeldtMedArbeidsgiver) {
+            return 'erSykemeldtMedArbeidsgiver';
+        }
+        if (oppfolging?.kanReaktiveres) {
+            return 'kanReaktiveres';
+        }
+        return 'kanIkkeReaktiveres';
+    };
 
     const brukerTekst = () => {
-        switch (brukerType) {
+        switch (brukerType()) {
             case 'erSykemeldtMedArbeidsgiver':
                 return 'Start oppfølging';
             case 'kanReaktiveres':

--- a/src/component/veilederverktoy/start-registrering/start-registrering-prosess.tsx
+++ b/src/component/veilederverktoy/start-registrering/start-registrering-prosess.tsx
@@ -31,8 +31,8 @@ function StartRegistreringProsess() {
     const brukerType = oppfolging?.erSykmeldtMedArbeidsgiver
         ? 'erSykemeldtMedArbeidsgiver'
         : oppfolging?.kanReaktiveres
-        ? 'kanReaktiveres'
-        : 'kanIkkeReaktiveres';
+          ? 'kanReaktiveres'
+          : 'kanIkkeReaktiveres';
 
     const brukerTekst = () => {
         switch (brukerType) {
@@ -48,13 +48,15 @@ function StartRegistreringProsess() {
     };
 
     return (
-        <a
-            href={byggRegistreringUrl(brukerFnr, enhetId, features[BRUK_GAMMEL_ARBEIDSREGISTRERING_URL])}
-            className="knapp meny-knapp btn--mb1"
-            onClick={() => logMetrikk('veilarbvisittkortfs.metrikker.registrering', {}, { brukerType: brukerType })}
-        >
-            {brukerTekst()}
-        </a>
+        <li>
+            <a
+                href={byggRegistreringUrl(brukerFnr, enhetId, features[BRUK_GAMMEL_ARBEIDSREGISTRERING_URL])}
+                className="knapp meny-knapp btn--mb1"
+                onClick={() => logMetrikk('veilarbvisittkortfs.metrikker.registrering', {}, { brukerType: brukerType })}
+            >
+                {brukerTekst()}
+            </a>
+        </li>
     );
 }
 

--- a/src/component/veilederverktoy/veilederverktoy-dropdown/veilederverktoy-dropdown.tsx
+++ b/src/component/veilederverktoy/veilederverktoy-dropdown/veilederverktoy-dropdown.tsx
@@ -12,11 +12,11 @@ interface DropdownProps {
     setApen: (apen: boolean) => void;
     lukkDropdown: () => void;
     btnRef: React.RefObject<HTMLButtonElement>;
-    render: (lukkDropdown: () => void) => ReactNode;
     onClick?: () => void;
+    children: ReactNode;
 }
 
-function VeilederverktoyDropdown({ apen, setApen, lukkDropdown, btnRef, render, onClick }: DropdownProps) {
+function VeilederverktoyDropdown({ apen, setApen, lukkDropdown, btnRef, onClick, children }: DropdownProps) {
     const loggNode = useRef<HTMLDivElement>(null);
 
     function toggleDropdown() {
@@ -59,7 +59,7 @@ function VeilederverktoyDropdown({ apen, setApen, lukkDropdown, btnRef, render, 
                     className="veilederverktoy-dropdown__innhold"
                     id="tildel-veileder-veilederverktoy-dropdown__innhold"
                 >
-                    {render(lukkDropdown)}
+                    {children}
                 </ul>
             )}
         </div>

--- a/src/component/veilederverktoy/veilederverktoy-dropdown/veilederverktoy-dropdown.tsx
+++ b/src/component/veilederverktoy/veilederverktoy-dropdown/veilederverktoy-dropdown.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useRef, useState } from 'react';
+import { ReactNode, useRef } from 'react';
 import classNames from 'classnames';
 import { Button } from '@navikt/ds-react';
 import { useDocumentEventListner } from '../../../util/hook/use-event-listner';
@@ -8,21 +8,16 @@ import hiddenIf from '../../components/hidden-if/hidden-if';
 import './veilederverktoy-dropdown.less';
 
 interface DropdownProps {
+    apen: boolean;
+    setApen: (apen: boolean) => void;
+    lukkDropdown: () => void;
+    btnRef: React.RefObject<HTMLButtonElement>;
     render: (lukkDropdown: () => void) => ReactNode;
     onClick?: () => void;
 }
 
-function VeilederverktoyDropdown({ render, onClick }: DropdownProps) {
-    const [apen, setApen] = useState(false);
-    const btnRef = useRef<HTMLButtonElement>(null);
+function VeilederverktoyDropdown({ apen, setApen, lukkDropdown, btnRef, render, onClick }: DropdownProps) {
     const loggNode = useRef<HTMLDivElement>(null);
-
-    const lukkDropdown = () => {
-        if (apen) {
-            setApen(false);
-            btnRef.current?.focus();
-        }
-    };
 
     function toggleDropdown() {
         if (apen) {

--- a/src/component/veilederverktoy/veilederverktoy-dropdown/veilederverktoy-dropdown.tsx
+++ b/src/component/veilederverktoy/veilederverktoy-dropdown/veilederverktoy-dropdown.tsx
@@ -1,20 +1,18 @@
 import { ReactNode, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { Button } from '@navikt/ds-react';
-import './veilederverktoy-dropdown.less';
 import { useDocumentEventListner } from '../../../util/hook/use-event-listner';
 import TannHjulIkon from '../../veilederverktoy/tannhjul.svg?react';
 import withClickMetric from '../../components/click-metric/click-metric';
 import hiddenIf from '../../components/hidden-if/hidden-if';
+import './veilederverktoy-dropdown.less';
 
 interface DropdownProps {
-    name: string;
-    knappeTekst: ReactNode;
     render: (lukkDropdown: () => void) => ReactNode;
     onClick?: () => void;
 }
 
-function VeilederverktoyDropdown({ name, knappeTekst, render, onClick }: DropdownProps) {
+function VeilederverktoyDropdown({ render, onClick }: DropdownProps) {
     const [apen, setApen] = useState(false);
     const btnRef = useRef<HTMLButtonElement>(null);
     const loggNode = useRef<HTMLDivElement>(null);
@@ -51,18 +49,21 @@ function VeilederverktoyDropdown({ name, knappeTekst, render, onClick }: Dropdow
         >
             <Button
                 variant="tertiary-neutral"
-                icon={<TannHjulIkon className="veilederverktoy-ikon" />}
+                icon={<TannHjulIkon className="veilederverktoy-ikon" aria-hidden={true} />}
                 ref={btnRef}
                 className="veilederverktoy-dropdown__btn"
                 onClick={toggleDropdown}
                 aria-expanded={apen}
-                aria-controls={`${name}-veilederverktoy-dropdown__innhold`}
+                aria-controls="tildel-veileder-veilederverktoy-dropdown__innhold"
                 type="button"
             >
-                {knappeTekst}
+                Veilederverktøy
             </Button>
             {apen && (
-                <ul className={'veilederverktoy-dropdown__innhold'} id={`${name}-veilederverktoy-dropdown__innhold`}>
+                <ul
+                    className="veilederverktoy-dropdown__innhold"
+                    id="tildel-veileder-veilederverktoy-dropdown__innhold"
+                >
                     {render(lukkDropdown)}
                 </ul>
             )}

--- a/src/component/veilederverktoy/veilederverktoylinje.tsx
+++ b/src/component/veilederverktoy/veilederverktoylinje.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react';
 import VeilederverktoyDropdown from './veilederverktoy-dropdown/veilederverktoy-dropdown';
 import StartRegistreringProsess from './start-registrering/start-registrering-prosess';
 import StartProsess from './prosess/start-prosess';
@@ -27,6 +28,9 @@ import { useOppfolgingsstatus, useTilgangTilBrukersKontor } from '../../api/veil
 import './veilederverktoy.less';
 
 function Veilederverktoylinje() {
+    const [dropdownApen, setDropdownApen] = useState(false);
+    const dropdownBtnRef = useRef<HTMLButtonElement>(null);
+
     const { visVeilederVerktoy, brukerFnr } = useAppStore();
     const { oppfolging, innloggetVeileder, gjeldendeEskaleringsvarsel, features } = useDataStore();
     const { data: oppfolgingsstatus } = useOppfolgingsstatus(brukerFnr);
@@ -116,9 +120,20 @@ function Veilederverktoylinje() {
         showHuskelappRedigereModal();
     };
 
+    const lukkDropdown = () => {
+        if (dropdownApen) {
+            setDropdownApen(false);
+            dropdownBtnRef.current?.focus();
+        }
+    };
+
     return (
         <div className="veilederverktoy-dropdown">
             <VeilederverktoyDropdown
+                apen={dropdownApen}
+                setApen={setDropdownApen}
+                lukkDropdown={lukkDropdown}
+                btnRef={dropdownBtnRef}
                 metricName="dropdown-trykket"
                 render={(lukkDropdown: () => void) => (
                     <>

--- a/src/component/veilederverktoy/veilederverktoylinje.tsx
+++ b/src/component/veilederverktoy/veilederverktoylinje.tsx
@@ -120,9 +120,7 @@ function Veilederverktoylinje() {
         <div className="veilederverktoy-dropdown">
             <VeilederverktoyDropdown
                 metricName="dropdown-trykket"
-                knappeTekst="Veilederverktøy"
-                name="tildel veileder"
-                render={lukkDropdown => (
+                render={(lukkDropdown: () => void) => (
                     <>
                         {sjekkHarTilgangTilHuskelappEllerFargekategori && (
                             <>

--- a/src/component/veilederverktoy/veilederverktoylinje.tsx
+++ b/src/component/veilederverktoy/veilederverktoylinje.tsx
@@ -135,138 +135,135 @@ function Veilederverktoylinje() {
                 lukkDropdown={lukkDropdown}
                 btnRef={dropdownBtnRef}
                 metricName="dropdown-trykket"
-                render={(lukkDropdown: () => void) => (
+            >
+                {sjekkHarTilgangTilHuskelappEllerFargekategori && (
                     <>
-                        {sjekkHarTilgangTilHuskelappEllerFargekategori && (
-                            <>
-                                {kanEndreArbeidsliste && !features[HUSKELAPP] && (
-                                    <li>
-                                        <StartProsess
-                                            knappeTekst="Rediger arbeidsliste"
-                                            onClick={() => doAll(arbeidslisteKlikk, lukkDropdown)}
-                                        />
-                                    </li>
-                                )}
-                                {kanLagreArbeidsliste && !features[HUSKELAPP] && (
-                                    <li>
-                                        <StartProsess
-                                            knappeTekst="Legg i arbeidsliste"
-                                            onClick={() => doAll(arbeidslisteKlikk, lukkDropdown)}
-                                        />
-                                    </li>
-                                )}
-                                {huskelapp?.huskelappId && features[HUSKELAPP] && (
-                                    <li>
-                                        <StartProsess
-                                            knappeTekst="Rediger huskelapp"
-                                            onClick={() => doAll(huskelappKlikk, lukkDropdown)}
-                                        />
-                                    </li>
-                                )}
-                                {huskelapp === null && features[HUSKELAPP] && (
-                                    <li>
-                                        <StartProsess
-                                            knappeTekst="Lag huskelapp"
-                                            onClick={() => doAll(huskelappKlikk, lukkDropdown)}
-                                        />
-                                    </li>
-                                )}
-                            </>
-                        )}
-                        {kanTildeleVeileder && (
+                        {kanEndreArbeidsliste && !features[HUSKELAPP] && (
                             <li>
                                 <StartProsess
-                                    metricName="tildel_veileder"
-                                    knappeTekst="Tildel veileder"
-                                    onClick={() => doAll(showTildelVeilederModal, lukkDropdown)}
+                                    knappeTekst="Rediger arbeidsliste"
+                                    onClick={() => doAll(arbeidslisteKlikk, lukkDropdown)}
                                 />
                             </li>
                         )}
-                        {kanStarteEskalering && (
+                        {kanLagreArbeidsliste && !features[HUSKELAPP] && (
                             <li>
                                 <StartProsess
-                                    knappeTekst="Send varsel"
-                                    onClick={() => doAll(showStartEskaleringModal, lukkDropdown)}
-                                    metricName="send_eskalering"
+                                    knappeTekst="Legg i arbeidsliste"
+                                    onClick={() => doAll(arbeidslisteKlikk, lukkDropdown)}
                                 />
                             </li>
                         )}
-                        {kanStoppeEskalering && (
+                        {huskelapp?.huskelappId && features[HUSKELAPP] && (
                             <li>
                                 <StartProsess
-                                    knappeTekst="Deaktiver varsel"
-                                    onClick={() => doAll(showStoppEskaleringModal, lukkDropdown)}
-                                    metricName="deaktiver_esklaring"
+                                    knappeTekst="Rediger huskelapp"
+                                    onClick={() => doAll(huskelappKlikk, lukkDropdown)}
                                 />
                             </li>
                         )}
-                        {kanRegistrere && (
-                            <li>
-                                <StartRegistreringProsess />
-                            </li>
-                        )}
-                        {kanStarteManuellOppfolging && (
+                        {huskelapp === null && features[HUSKELAPP] && (
                             <li>
                                 <StartProsess
-                                    knappeTekst="Endre til manuell oppfølging"
-                                    onClick={() => doAll(showStartManuellOppfolgingModal, lukkDropdown)}
-                                    metricName="manuell"
+                                    knappeTekst="Lag huskelapp"
+                                    onClick={() => doAll(huskelappKlikk, lukkDropdown)}
                                 />
                             </li>
                         )}
-                        {kanStarteDigitalOppfolging && (
-                            <li>
-                                <StartProsess
-                                    knappeTekst="Endre til digital oppfølging"
-                                    onClick={() => doAll(showStartDigitalOppfolgingModal, lukkDropdown)}
-                                    metricName="digital"
-                                />
-                            </li>
-                        )}
-                        {kanStarteKVP && (
-                            <li>
-                                <StartProsess
-                                    knappeTekst="Start KVP-periode"
-                                    onClick={() => doAll(showStartKvpPeriodeModal, lukkDropdown)}
-                                    metricName="start_kvp"
-                                />
-                            </li>
-                        )}
-                        {kanStoppeKVP && (
-                            <li>
-                                <StartProsess
-                                    knappeTekst="Avslutt KVP-periode"
-                                    onClick={() => doAll(showStoppKvpPeriodeModal, lukkDropdown)}
-                                    metricName="stopp_kvp"
-                                />
-                            </li>
-                        )}
-                        <li>
-                            <StartProsess
-                                knappeTekst="Opprett Gosys-oppgave"
-                                onClick={() => doAll(showOpprettOppgaveModal, lukkDropdown)}
-                                metricName="gosys"
-                            />
-                        </li>
-                        {kanAvslutteOppfolging && (
-                            <li>
-                                <StartProsess
-                                    knappeTekst="Avslutt oppfølging"
-                                    onClick={() => doAll(showAvsluttOppfolgingModal, lukkDropdown)}
-                                    metricName="avslutt_oppfolging"
-                                />
-                            </li>
-                        )}
-                        <li>
-                            <StartProsess
-                                knappeTekst="Vis historikk"
-                                onClick={() => doAll(showHistorikkModal, lukkDropdown)}
-                                metricName="historikk"
-                            />
-                        </li>
                     </>
                 )}
-            />
+                {kanTildeleVeileder && (
+                    <li>
+                        <StartProsess
+                            metricName="tildel_veileder"
+                            knappeTekst="Tildel veileder"
+                            onClick={() => doAll(showTildelVeilederModal, lukkDropdown)}
+                        />
+                    </li>
+                )}
+                {kanStarteEskalering && (
+                    <li>
+                        <StartProsess
+                            knappeTekst="Send varsel"
+                            onClick={() => doAll(showStartEskaleringModal, lukkDropdown)}
+                            metricName="send_eskalering"
+                        />
+                    </li>
+                )}
+                {kanStoppeEskalering && (
+                    <li>
+                        <StartProsess
+                            knappeTekst="Deaktiver varsel"
+                            onClick={() => doAll(showStoppEskaleringModal, lukkDropdown)}
+                            metricName="deaktiver_esklaring"
+                        />
+                    </li>
+                )}
+                {kanRegistrere && (
+                    <li>
+                        <StartRegistreringProsess />
+                    </li>
+                )}
+                {kanStarteManuellOppfolging && (
+                    <li>
+                        <StartProsess
+                            knappeTekst="Endre til manuell oppfølging"
+                            onClick={() => doAll(showStartManuellOppfolgingModal, lukkDropdown)}
+                            metricName="manuell"
+                        />
+                    </li>
+                )}
+                {kanStarteDigitalOppfolging && (
+                    <li>
+                        <StartProsess
+                            knappeTekst="Endre til digital oppfølging"
+                            onClick={() => doAll(showStartDigitalOppfolgingModal, lukkDropdown)}
+                            metricName="digital"
+                        />
+                    </li>
+                )}
+                {kanStarteKVP && (
+                    <li>
+                        <StartProsess
+                            knappeTekst="Start KVP-periode"
+                            onClick={() => doAll(showStartKvpPeriodeModal, lukkDropdown)}
+                            metricName="start_kvp"
+                        />
+                    </li>
+                )}
+                {kanStoppeKVP && (
+                    <li>
+                        <StartProsess
+                            knappeTekst="Avslutt KVP-periode"
+                            onClick={() => doAll(showStoppKvpPeriodeModal, lukkDropdown)}
+                            metricName="stopp_kvp"
+                        />
+                    </li>
+                )}
+                <li>
+                    <StartProsess
+                        knappeTekst="Opprett Gosys-oppgave"
+                        onClick={() => doAll(showOpprettOppgaveModal, lukkDropdown)}
+                        metricName="gosys"
+                    />
+                </li>
+                {kanAvslutteOppfolging && (
+                    <li>
+                        <StartProsess
+                            knappeTekst="Avslutt oppfølging"
+                            onClick={() => doAll(showAvsluttOppfolgingModal, lukkDropdown)}
+                            metricName="avslutt_oppfolging"
+                        />
+                    </li>
+                )}
+                <li>
+                    <StartProsess
+                        knappeTekst="Vis historikk"
+                        onClick={() => doAll(showHistorikkModal, lukkDropdown)}
+                        metricName="historikk"
+                    />
+                </li>
+            </VeilederverktoyDropdown>
         </div>
     );
 }

--- a/src/component/veilederverktoy/veilederverktoylinje.tsx
+++ b/src/component/veilederverktoy/veilederverktoylinje.tsx
@@ -139,130 +139,98 @@ function Veilederverktoylinje() {
                 {sjekkHarTilgangTilHuskelappEllerFargekategori && (
                     <>
                         {kanEndreArbeidsliste && !features[HUSKELAPP] && (
-                            <li>
-                                <StartProsess
-                                    knappeTekst="Rediger arbeidsliste"
-                                    onClick={() => doAll(arbeidslisteKlikk, lukkDropdown)}
-                                />
-                            </li>
+                            <StartProsess
+                                knappeTekst="Rediger arbeidsliste"
+                                onClick={() => doAll(arbeidslisteKlikk, lukkDropdown)}
+                            />
                         )}
                         {kanLagreArbeidsliste && !features[HUSKELAPP] && (
-                            <li>
-                                <StartProsess
-                                    knappeTekst="Legg i arbeidsliste"
-                                    onClick={() => doAll(arbeidslisteKlikk, lukkDropdown)}
-                                />
-                            </li>
+                            <StartProsess
+                                knappeTekst="Legg i arbeidsliste"
+                                onClick={() => doAll(arbeidslisteKlikk, lukkDropdown)}
+                            />
                         )}
                         {huskelapp?.huskelappId && features[HUSKELAPP] && (
-                            <li>
-                                <StartProsess
-                                    knappeTekst="Rediger huskelapp"
-                                    onClick={() => doAll(huskelappKlikk, lukkDropdown)}
-                                />
-                            </li>
+                            <StartProsess
+                                knappeTekst="Rediger huskelapp"
+                                onClick={() => doAll(huskelappKlikk, lukkDropdown)}
+                            />
                         )}
                         {huskelapp === null && features[HUSKELAPP] && (
-                            <li>
-                                <StartProsess
-                                    knappeTekst="Lag huskelapp"
-                                    onClick={() => doAll(huskelappKlikk, lukkDropdown)}
-                                />
-                            </li>
+                            <StartProsess
+                                knappeTekst="Lag huskelapp"
+                                onClick={() => doAll(huskelappKlikk, lukkDropdown)}
+                            />
                         )}
                     </>
                 )}
                 {kanTildeleVeileder && (
-                    <li>
-                        <StartProsess
-                            metricName="tildel_veileder"
-                            knappeTekst="Tildel veileder"
-                            onClick={() => doAll(showTildelVeilederModal, lukkDropdown)}
-                        />
-                    </li>
+                    <StartProsess
+                        metricName="tildel_veileder"
+                        knappeTekst="Tildel veileder"
+                        onClick={() => doAll(showTildelVeilederModal, lukkDropdown)}
+                    />
                 )}
                 {kanStarteEskalering && (
-                    <li>
-                        <StartProsess
-                            knappeTekst="Send varsel"
-                            onClick={() => doAll(showStartEskaleringModal, lukkDropdown)}
-                            metricName="send_eskalering"
-                        />
-                    </li>
+                    <StartProsess
+                        knappeTekst="Send varsel"
+                        onClick={() => doAll(showStartEskaleringModal, lukkDropdown)}
+                        metricName="send_eskalering"
+                    />
                 )}
                 {kanStoppeEskalering && (
-                    <li>
-                        <StartProsess
-                            knappeTekst="Deaktiver varsel"
-                            onClick={() => doAll(showStoppEskaleringModal, lukkDropdown)}
-                            metricName="deaktiver_esklaring"
-                        />
-                    </li>
+                    <StartProsess
+                        knappeTekst="Deaktiver varsel"
+                        onClick={() => doAll(showStoppEskaleringModal, lukkDropdown)}
+                        metricName="deaktiver_esklaring"
+                    />
                 )}
-                {kanRegistrere && (
-                    <li>
-                        <StartRegistreringProsess />
-                    </li>
-                )}
+                {kanRegistrere && <StartRegistreringProsess />}
                 {kanStarteManuellOppfolging && (
-                    <li>
-                        <StartProsess
-                            knappeTekst="Endre til manuell oppfølging"
-                            onClick={() => doAll(showStartManuellOppfolgingModal, lukkDropdown)}
-                            metricName="manuell"
-                        />
-                    </li>
+                    <StartProsess
+                        knappeTekst="Endre til manuell oppfølging"
+                        onClick={() => doAll(showStartManuellOppfolgingModal, lukkDropdown)}
+                        metricName="manuell"
+                    />
                 )}
                 {kanStarteDigitalOppfolging && (
-                    <li>
-                        <StartProsess
-                            knappeTekst="Endre til digital oppfølging"
-                            onClick={() => doAll(showStartDigitalOppfolgingModal, lukkDropdown)}
-                            metricName="digital"
-                        />
-                    </li>
+                    <StartProsess
+                        knappeTekst="Endre til digital oppfølging"
+                        onClick={() => doAll(showStartDigitalOppfolgingModal, lukkDropdown)}
+                        metricName="digital"
+                    />
                 )}
                 {kanStarteKVP && (
-                    <li>
-                        <StartProsess
-                            knappeTekst="Start KVP-periode"
-                            onClick={() => doAll(showStartKvpPeriodeModal, lukkDropdown)}
-                            metricName="start_kvp"
-                        />
-                    </li>
+                    <StartProsess
+                        knappeTekst="Start KVP-periode"
+                        onClick={() => doAll(showStartKvpPeriodeModal, lukkDropdown)}
+                        metricName="start_kvp"
+                    />
                 )}
                 {kanStoppeKVP && (
-                    <li>
-                        <StartProsess
-                            knappeTekst="Avslutt KVP-periode"
-                            onClick={() => doAll(showStoppKvpPeriodeModal, lukkDropdown)}
-                            metricName="stopp_kvp"
-                        />
-                    </li>
-                )}
-                <li>
                     <StartProsess
-                        knappeTekst="Opprett Gosys-oppgave"
-                        onClick={() => doAll(showOpprettOppgaveModal, lukkDropdown)}
-                        metricName="gosys"
+                        knappeTekst="Avslutt KVP-periode"
+                        onClick={() => doAll(showStoppKvpPeriodeModal, lukkDropdown)}
+                        metricName="stopp_kvp"
                     />
-                </li>
+                )}
+                <StartProsess
+                    knappeTekst="Opprett Gosys-oppgave"
+                    onClick={() => doAll(showOpprettOppgaveModal, lukkDropdown)}
+                    metricName="gosys"
+                />
                 {kanAvslutteOppfolging && (
-                    <li>
-                        <StartProsess
-                            knappeTekst="Avslutt oppfølging"
-                            onClick={() => doAll(showAvsluttOppfolgingModal, lukkDropdown)}
-                            metricName="avslutt_oppfolging"
-                        />
-                    </li>
-                )}
-                <li>
                     <StartProsess
-                        knappeTekst="Vis historikk"
-                        onClick={() => doAll(showHistorikkModal, lukkDropdown)}
-                        metricName="historikk"
+                        knappeTekst="Avslutt oppfølging"
+                        onClick={() => doAll(showAvsluttOppfolgingModal, lukkDropdown)}
+                        metricName="avslutt_oppfolging"
                     />
-                </li>
+                )}
+                <StartProsess
+                    knappeTekst="Vis historikk"
+                    onClick={() => doAll(showHistorikkModal, lukkDropdown)}
+                    metricName="historikk"
+                />
             </VeilederverktoyDropdown>
         </div>
     );


### PR DESCRIPTION
Eit steg i å kunne bytte til designsystemet sin Dropdown-komponent i staden for den heimelaga komponenten i har no.

Her har eg flytta hardkoda props inn i inner-komponenten, gjort den om til ein kontrollert komponent og bytta ut `render`-funksjonen med `children`.