### PR TITLE
Fjerne kall mot hent-registrering som igjen går mot veilarbregistrering som skal saneres

### DIFF
--- a/src/api/veilarbperson.ts
+++ b/src/api/veilarbperson.ts
@@ -96,18 +96,24 @@ export interface PdlRequest {
     behandlingsnummer: string;
 }
 
-export type RegistreringType = 'ORDINAER' | 'SYKMELDT';
-export type InnsatsgruppeType = 'STANDARD_INNSATS' | 'SITUASJONSBESTEMT_INNSATS' | 'BEHOV_FOR_ARBEIDSEVNEVURDERING';
-
-export interface RegistreringData {
-    type: RegistreringType;
-    registrering: {
-        profilering?: {
-            jobbetSammenhengendeSeksAvTolvSisteManeder: boolean;
-            innsatsgruppe: InnsatsgruppeType;
+export type Profilering = {
+    profileringId: string;
+    periodeId: string;
+    opplysningerOmArbeidssoekerId: string;
+    sendtInnAv: {
+        tidspunkt: string;
+        utfoertAv: {
+            type: string;
         };
-        manueltRegistrertAv: object | null;
+        kilde: string;
+        aarsak: string;
     };
+    profilertTil: string;
+    jobbetSammenhengendeSeksAvTolvSisteManeder: boolean;
+    alder: number;
+};
+export interface OpplysningerOmArbeidssoekerMedProfilering {
+    profilering: Profilering;
 }
 
 export function fetchPersonalia(fnr: string, behandlingsnummer: string): AxiosPromise<Personalia> {
@@ -142,10 +148,15 @@ export function fetchHarNivaa4(fnr: string): AxiosPromise<HarBruktNivaa4Type> {
     return axiosInstance.get<HarBruktNivaa4Type>(`/veilarbperson/api/person/${fnr}/harNivaa4`);
 }
 
-export function fetchRegistrering(fnr: string): AxiosPromise<RegistreringData> {
-    return axiosInstance.post<RegistreringData>(`/veilarbperson/api/v3/person/hent-registrering`, {
-        fnr: fnr
-    } as PersonRequest);
+export function fetchProfileringFraArbeidssoekerregisteret(
+    fnr: string
+): AxiosPromise<OpplysningerOmArbeidssoekerMedProfilering> {
+    return axiosInstance.post<OpplysningerOmArbeidssoekerMedProfilering>(
+        `/veilarbperson/api/v3/person/hent-siste-opplysninger-om-arbeidssoeker-med-profilering`,
+        {
+            fnr: fnr
+        } as PersonRequest
+    );
 }
 
 export function sendEventTilVeilarbperson(event: FrontendEvent): AxiosPromise<void> {

--- a/src/component/veilederverktoy/start-manuell-oppfolging/start-manuell-oppfolging-kvittering.tsx
+++ b/src/component/veilederverktoy/start-manuell-oppfolging/start-manuell-oppfolging-kvittering.tsx
@@ -1,44 +1,11 @@
-import { useEffect, useState } from 'react';
 import { Alert } from '@navikt/ds-react';
 import Kvittering from '../prosess/kvittering';
-import { logMetrikk } from '../../../util/logger';
-import { useAppStore } from '../../../store/app-store';
-import { useDataStore } from '../../../store/data-store';
-import { useAxiosFetcher } from '../../../util/hook/use-axios-fetcher';
-import { fetchRegistrering } from '../../../api/veilarbperson';
 
 export interface StartManuellOppfolgingKvitteringProps {
     begrunnelse: string;
 }
 
 function StartManuellOppfolgingKvittering({ begrunnelse }: StartManuellOppfolgingKvitteringProps) {
-    const { brukerFnr } = useAppStore();
-    const { oppfolging } = useDataStore();
-
-    const registreringFetcher = useAxiosFetcher(fetchRegistrering);
-    const [harLoggetMetrikk, setHarLoggetMetrikk] = useState(false);
-
-    useEffect(() => {
-        registreringFetcher.fetch(brukerFnr);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [brukerFnr]);
-
-    useEffect(() => {
-        if (registreringFetcher.data && !harLoggetMetrikk) {
-            const registreringData = registreringFetcher.data;
-            const erManueltRegistrert = !!registreringData.registrering.manueltRegistrertAv;
-            const logFields = {
-                brukerType: registreringData.type,
-                erKRR: !!oppfolging?.reservasjonKRR,
-                erManueltRegistrert
-            };
-
-            logMetrikk('veilarbvisittkortfs.metrikker.manuell_oppfolging', logFields);
-            setHarLoggetMetrikk(true);
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [registreringFetcher]);
-
     return (
         <Kvittering
             tittel="Endre til manuell oppfølging"

--- a/src/mock/api/veilarbperson.ts
+++ b/src/mock/api/veilarbperson.ts
@@ -2,11 +2,11 @@ import {
     HarBruktNivaa4Type,
     Personalia,
     PersonaliaTelefon,
-    RegistreringData,
     SpraakTolk,
     Verge,
     FullmaktDTO,
-    OmraadeHandlingType
+    OmraadeHandlingType,
+    OpplysningerOmArbeidssoekerMedProfilering
 } from '../../api/veilarbperson';
 import { defaultNetworkResponseDelay } from '../config';
 import { delay, http, HttpResponse, RequestHandler } from 'msw';
@@ -113,18 +113,26 @@ const mockSpraakTolk: SpraakTolk = {
     talespraak: 'Engelsk'
 };
 
-const mockRegistrering: RegistreringData = {
-    type: 'ORDINAER',
-    registrering: {
-        manueltRegistrertAv: null
+const mockProfileringFraArbeidssoekerregisteret: OpplysningerOmArbeidssoekerMedProfilering = {
+    profilering: {
+        profileringId: 'profilering-id-123',
+        periodeId: 'periode-id-123',
+        opplysningerOmArbeidssoekerId: 'opplysninger-om-arbeidssoeker-id-123',
+        sendtInnAv: {
+            tidspunkt: '2021-03-02T13:00:42',
+            utfoertAv: {
+                type: 'SLUTTBRUKER'
+            },
+            kilde: '',
+            aarsak: ''
+        },
+        profilertTil: 'OPPGITT_HINDRINGER',
+        jobbetSammenhengendeSeksAvTolvSisteManeder: true,
+        alder: 24
     }
 };
 
 export const veilarbpersonHandlers: RequestHandler[] = [
-    http.post('/veilarbperson/api/v3/person/hent-registrering', async () => {
-        await delay(defaultNetworkResponseDelay);
-        return HttpResponse.json(mockRegistrering);
-    }),
     http.get('/veilarbperson/api/person/:fnr/harNivaa4', async () => {
         await delay(defaultNetworkResponseDelay);
         return HttpResponse.json(mockHarBruktNivaa4);
@@ -144,5 +152,10 @@ export const veilarbpersonHandlers: RequestHandler[] = [
     http.post('/veilarbperson/api/v3/person/hent-tolk', async () => {
         await delay(defaultNetworkResponseDelay);
         return HttpResponse.json(mockSpraakTolk);
+    }),
+    http.post('/veilarbperson/api/v3/person/hent-siste-opplysninger-om-arbeidssoeker-med-profilering', async () => {
+        await delay(defaultNetworkResponseDelay);
+
+        return HttpResponse.json(mockProfileringFraArbeidssoekerregisteret);
     })
 ];


### PR DESCRIPTION
* Fjernet fra kvittering for manuell-registrering. Ble brukt til metrikker som per nå ikke går noen sted siden vi har skrudd av influx. Har heller ikke sett noen grafana boards som tracker denne metrikken.
* Erstatter kall fra veilarbregistrering til arbeidssøkerregisteret for etiketter. Dette er togglet av per nå. Uklart på hvorfor denne ble satt til false isteden for å lytte på unleash. toggelen iseg selv har vært bugget så vi har en trellotask på å få fikset denne togglen: https://trello.com/c/LSoL09ua/321-ptovedtaksstottepilot-funksjonsbryter-er-bugget 