### PR TITLE
📊  Legg til begrunnelse i start eskalering payload

### DIFF
--- a/src/api/veilarbdialog.ts
+++ b/src/api/veilarbdialog.ts
@@ -23,7 +23,7 @@ export interface StartEskaleringRequest {
     begrunnelse: string;
     overskrift: string;
     tekst: string;
-    type: string;
+    begrunnelseType: string;
 }
 
 export interface StopEskaleringRequest {

--- a/src/api/veilarbdialog.ts
+++ b/src/api/veilarbdialog.ts
@@ -23,6 +23,7 @@ export interface StartEskaleringRequest {
     begrunnelse: string;
     overskrift: string;
     tekst: string;
+    type: string;
 }
 
 export interface StopEskaleringRequest {

--- a/src/component/veilederverktoy/start-eskalering/start-eskalering.tsx
+++ b/src/component/veilederverktoy/start-eskalering/start-eskalering.tsx
@@ -41,7 +41,8 @@ function StartEskalering() {
                 fnr: brukerFnr,
                 begrunnelse: values.begrunnelse,
                 overskrift: values.overskrift,
-                tekst: values.begrunnelse
+                tekst: values.begrunnelse,
+                type: values.type
             });
 
             logMetrikk(

--- a/src/component/veilederverktoy/start-eskalering/start-eskalering.tsx
+++ b/src/component/veilederverktoy/start-eskalering/start-eskalering.tsx
@@ -42,7 +42,7 @@ function StartEskalering() {
                 begrunnelse: values.begrunnelse,
                 overskrift: values.overskrift,
                 tekst: values.begrunnelse,
-                type: values.type
+                begrunnelseType: values.type
             });
 
             logMetrikk(


### PR DESCRIPTION
Siden migrering til gcp har ikke metrikk-løsninger basert på indluxDB fungert, og foreløpig er det på plass en løsning hvor veilarbdialog sender events til bigquery. For å ha tilsvarende metrikker i BigQuery trenger man begrunnelse i payload
