### PR TITLE
Oppdater dependabotgrupperingar

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,7 @@ updates:
           - '@testing-library/react'
           - 'jsdom'
           - 'vitest'
+      typescript:
+        patterns:
+          - 'typescript'
+          - 'typescript-eslint'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,7 @@ updates:
           - 'eslint*'
           - 'globals'
           - 'typescript-eslint'
+          - '@eslint/*'
       workflow-tools:
         patterns:
           - 'husky'


### PR DESCRIPTION
Gjer det lettare for dependabot å oppdatere ting som høyrer saman samstundes. Vil forhåpentlegvis føre til færre raude bygg-sjekkar.

- Legg til @eslint-pakkane i eslint-mønsteret
- Legg til typescript-eslint-pakken i ei ny typescript-gruppe, sidan typescript-oppdateringar kan køyre raudt om denne pakken ikkje støtter nye typescriptversjonar.