### PR TITLE
Unngå at vi viser "I Arbeidssøkerregisteret"-etiketten dersom responsen returnerer 204 og tom body

### DIFF
--- a/src/component/personinfo/components/etiketter.tsx
+++ b/src/component/personinfo/components/etiketter.tsx
@@ -135,8 +135,8 @@ function Etiketter() {
         if (features?.[VIS_I_ARBEIDSSOKERREGISTERET_ETIKETT]) {
             return (
                 !opplysningerOmArbeidssoekerLoading &&
-                opplysningerOmArbeidssoeker !== null &&
-                opplysningerOmArbeidssoeker !== undefined
+                opplysningerOmArbeidssoeker?.arbeidssoekerperiodeStartet !== null &&
+                opplysningerOmArbeidssoeker?.arbeidssoekerperiodeStartet !== undefined
             );
         }
 


### PR DESCRIPTION
Endepunktet `/hent-siste-opplysninger-om-arbeidssoeker-med-profilering` returnerer `HTTP 204` og tom respons-body dersom personen ikkje har nokon arbeidssøkarperiode. I [handleResponse-metoden](https://github.com/navikt/veilarbvisittkortfs/blob/1c60252186299ebfe88dc79539f823b55233b252/src/api/utils.ts#L79-L84) blir `204` mappa til eit error-objekt som gjer at det ikkje er tilstrekkeleg å sjekke på om `opplysningerOmArbeidssoeker` ikkje er `undefined` eller `null`; vi lyt også sjekke om den har ein av property-ane ein faktisk arbeidssøkerperiode-respons ville innehaldt. Visst ikkje kan vi få `true` sjølv om `opplysningerOmArbeidssoeker` eigentleg til dømes er `{}`.