### PR TITLE
Sette loggdestinasjonar eksplisitt

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -32,6 +32,11 @@ spec:
     buckets:
       - name: veilarbvisittkortfs-dev
         cascadingDelete: false
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   env:
     - name: JSON_CONFIG
       value: >

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -31,6 +31,11 @@ spec:
     buckets:
       - name: veilarbvisittkortfs-prod
         cascadingDelete: false
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   env:
     - name: JSON_CONFIG
       value: >


### PR DESCRIPTION
[Nais skal/har gått over til Grafana Loki som default loggverktøy og Elastic Kibana er difor deprekert](https://nav-it.slack.com/docs/T5LNAMWNA/F08RNSRJ934). Elastic vil vere tilgjengeleg ut året, så inntil vi får migrert til Grafana Loki, må vi eksplisitt spesifisere Elastic Kibana som loggdestinasjon. Legg difor til både `elastic` og `loki` som loggdestinasjonar slik at vi kan halde fram med å få loggar i Kibana. Når vi er blitt vande nok med Loki kan vi gå over permanent og fjerne `elastic`.