### PR TITLE
legger til cooldown for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,15 @@ updates:
     directory: "/.github/workflows"
     schedule:
       interval: "weekly"
+    cooldown:
+        default-days: 3
 
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+        default-days: 3
     groups:
       aksel-dependencies:
         patterns:


### PR DESCRIPTION
For å redusere risikoen for å få inn kompromitterte versjoner av avhengigheter som inneholder sikkerhetshull er det anbefalt å ha en cooldown for dependabot slik at pakker med ondsinnet kode rekker å bli fjernet før dependabot varsler oss om den nye versjonen. 