### PR TITLE
Unngå at etiketter utvider seg horisontalt

### DIFF
--- a/src/component/personinfo/components/etiketter.tsx
+++ b/src/component/personinfo/components/etiketter.tsx
@@ -113,7 +113,7 @@ function Etiketter({ brukerFnr }: { brukerFnr: string }) {
     }
 
     return (
-        <HStack className="etikett-container" gap="space-2 space-4" wrap>
+        <HStack className="etikett-container" align="center" gap="space-2 space-4" wrap>
             <BaseDod visible={!!personalia?.dodsdato}>Død</BaseDod>
             <Advarsel visible={!!personalia?.diskresjonskode}>Kode {personalia?.diskresjonskode}</Advarsel>
             <Advarsel visible={!!personalia?.sikkerhetstiltak}>{personalia?.sikkerhetstiltak}</Advarsel>


### PR DESCRIPTION
Før:
<img width="963" height="105" alt="Skjermbilde 2026-04-15 kl  15 02 41" src="https://github.com/user-attachments/assets/71aa446a-2407-4419-8c60-4dc1de36706c" />

Etter:
<img width="902" height="81" alt="Skjermbilde 2026-04-15 kl  15 02 36" src="https://github.com/user-attachments/assets/b7db61d3-0815-45c4-b1a3-506bbed7133f" />
