### PR TITLE
fjerner ytelser fra arena fra respons og advarsel ved avslutning

### DIFF
--- a/src/api/veilarboppfolging.ts
+++ b/src/api/veilarboppfolging.ts
@@ -32,7 +32,6 @@ export interface OppfolgingStatus {
 }
 
 export interface AvslutningStatus {
-    harYtelser: boolean;
     inaktiveringsDato: StringOrNothing;
     kanAvslutte: boolean;
     underKvp: boolean;

--- a/src/component/veilederverktoy/avsluttoppfolging/components/avslutt-oppfolging-info-text.tsx
+++ b/src/component/veilederverktoy/avsluttoppfolging/components/avslutt-oppfolging-info-text.tsx
@@ -5,17 +5,11 @@ import { useAxiosFetcher } from '../../../../util/hook/use-axios-fetcher';
 
 interface Props {
     fnr: string;
-    harYtelser?: boolean;
     datoErInnenFor28DagerSiden: boolean;
     harUbehandledeDialoger: boolean;
 }
 
-export function AvsluttOppfolgingInfoText({
-    fnr,
-    harYtelser,
-    datoErInnenFor28DagerSiden,
-    harUbehandledeDialoger
-}: Props) {
+export function AvsluttOppfolgingInfoText({ fnr, datoErInnenFor28DagerSiden, harUbehandledeDialoger }: Props) {
     const harArenaTiltakFetcher = useAxiosFetcher(fetchHarArenaTiltak);
     const { data: harUtkast, isLoading: harUtkastIsLoading } = useHarUtkast(fnr);
 
@@ -35,14 +29,13 @@ export function AvsluttOppfolgingInfoText({
             <BodyShort size="small" spacing={true}>
                 {aktivMindreEnn28Dager}
             </BodyShort>
-            {(harUbehandledeDialoger || harArenaTiltak || harYtelser) && (
+            {(harUbehandledeDialoger || harArenaTiltak) && (
                 <Alert variant="warning" size="small">
                     Du kan avslutte oppfølgingsperioden selv om:
                     <ul className="margin--0">
                         {harUbehandledeDialoger && <li>Brukeren har ubehandlede dialoger</li>}
                         {hentTiltakFeilet && <li>Brukeren kan ha aktive tiltak i Arena</li>}
                         {!hentTiltakFeilet && harArenaTiltak && <li>Brukeren har aktive tiltak i Arena</li>}
-                        {harYtelser && <li>Brukeren har aktive saker i Arena</li>}
                     </ul>
                 </Alert>
             )}

--- a/src/mock/api/veilarboppfolging.ts
+++ b/src/mock/api/veilarboppfolging.ts
@@ -12,7 +12,6 @@ import { GraphqlResponse } from '../../api/GraphqlUtils';
 
 const mockAvslutningStatus: AvslutningStatus = {
     kanAvslutte: true,
-    harYtelser: false,
     underOppfolging: true,
     inaktiveringsDato: null,
     underKvp: false,
@@ -25,7 +24,6 @@ const mockAvslutningStatus: AvslutningStatus = {
 
 const mockOppfolgingAvsluttetStatus: AvslutningStatus = {
     kanAvslutte: false,
-    harYtelser: true,
     underOppfolging: false,
     inaktiveringsDato: null,
     underKvp: false,


### PR DESCRIPTION
Fjerner harYtelser fra responsen fra backend siden vi ønsker å slutte å hente ytelser fra Arena. Tar også bort advarselen om ytelser i Arena. 

Må merges før https://github.com/navikt/veilarboppfolging/pull/979. 

https://trello.com/c/Vo1hQxS7/1658-fjerne-kall-til-ytelser-tjenesten-i-arena